### PR TITLE
test: pass with no tests for now

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,11 @@
 const config = {
   clearMocks: true,
+  collectCoverage: true,
   coverageDirectory: "coverage",
   coverageProvider: "v8",
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  verbose: true,
 };
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "lint:fix": "eslint --fix .",
     "format": "prettier --check \"./**/*.{ts,tsx,js,css,json,md}\"",
     "format:fix": "prettier --write  \"./**/*.{ts,tsx,js,css,json,md}\"",
-    "test": "jest --coverage",
-    "test:ci": "jest --ci",
-    "test:watch": "jest --watch",
+    "test": "jest --passWithNoTests",
+    "test:ci": "jest --passWithNoTests --ci",
+    "test:watch": "jest --passWithNoTests --watch",
     "release": "cross-env HUSKY_SKIP_HOOKS=1 standard-version",
     "release:next": "cross-env HUSKY_SKIP_HOOKS=1 standard-version --prerelease next"
   },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,0 @@
-/*
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */


### PR DESCRIPTION
## Description

Instructed `jest` to pass when no tests are present.

## Related Issue
N/A

## Motivation and Context

As this project is brand new, let's not have the [`integration`](https://github.com/adobe/magento-storefront-event-collector/actions/workflows/integration.yml) action fail because no tests are present.

## How Has This Been Tested?

Running `npm run test` no longer fails.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
