### PR TITLE
chore: ignore changelog in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ coverage
 
 # misc
 .env
+CHANGELOG.md


### PR DESCRIPTION
## Description

Ignore `CHANGELOG.md` when running `prettier`.

## Related Issue

N/A

## Motivation and Context

The `CHANGELOG.md` file is generated by [standard-version](https://github.com/adobe/magento-storefront-events-sdk/actions/runs/665426980) and should be ignored when formatting, as it will cause `prettier` to fail.

## How Has This Been Tested?

Tested locally by running `npm run format`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
