### PR TITLE
SEARCH-1105 | construct snowplow contexts from data layer

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -6,45 +6,50 @@
 
         <script>
             window.magentoStorefrontEvents.context.setSearchInput({
-                searchType: "popover",
+                source: "search-bar",
                 query: "red patns",
+                page: 1,
+                perPage: 20,
                 refinementAttribute: null,
                 refinementSelection: null,
+                sortType: "relevance",
+                sortOrder: "descending",
             });
 
             window.magentoStorefrontEvents.context.setSearchResults({
                 products: [
                     {
-                        title: "Hoodie",
-                        url: "https://magento.com/hoodie",
-                        rank: 1,
-                        resultType: "product",
+                        name: "Red Pants",
                         sku: "abc123",
-                        imageUrl: "https://magento.com/hoodie.jpg",
-                        price: "49.99",
+                        url: "https://magento.com/red-pants",
+                        imageUrl: "https://magento.com/red-pants.jpg",
+                        price: 49.99,
+                        rank: 1,
                     },
                 ],
                 suggestions: [
                     {
-                        title: "Hoodie",
-                        url: "https://magento.com/shirt",
+                        suggestion: "red pants",
                         rank: 1,
-                        resultType: "suggestion",
-                        sku: "abc123",
-                        imageUrl: "https://magento.com/shirt/shirt.jpg",
-                        price: "19.99",
                     },
                 ],
                 categories: [
                     {
-                        title: "Tops",
-                        url: "https://magento.com/tops",
+                        name: "Pants",
+                        url: "https://magento.com/category/pants",
                         rank: 1,
-                        resultType: "category",
+                    },
+                    {
+                        name: "Bottoms",
+                        url: "https://magento.com/category/bottoms",
+                        rank: 2,
                     },
                 ],
                 page: 1,
                 perPage: 20,
+                productCount: 1,
+                categoryCount: 2,
+                suggestionCount: 1,
             });
 
             function fireEvent(event) {

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -3,16 +3,28 @@
  * See COPYING.txt for license details.
  */
 
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+    createSearchResultSuggestionContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
+
     trackEvent({
         category: "search",
         action: "category-click",
         label: "<categoryUrlKey>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [
+            searchInputCtx,
+            searchResultsCtx,
+            searchResultsSuggestionCtx,
+        ],
     });
 };
 

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -3,20 +3,24 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultProductContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsProductCtx = createSearchResultProductContext();
 
     trackEvent({
         category: "search",
         action: "product-click",
         label: "<sku>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx, searchResultsProductCtx],
     });
 };
 

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -3,19 +3,18 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import { createSearchInputContext } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
+    const searchInputCtx = createSearchInputContext();
 
     trackEvent({
         category: "search",
         action: "api-request-sent",
         label: "<query>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx],
     });
 };
 

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -3,19 +3,22 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
 
     trackEvent({
         category: "search",
         action: "api-response-received",
         label: "<query>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx],
     });
 };
 

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -3,20 +3,22 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
 
     trackEvent({
         category: "search",
         action: "results-view",
         label: "",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx],
     });
 };
 

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -3,20 +3,28 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+    createSearchResultSuggestionContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
 
     trackEvent({
         category: "search",
         action: "suggestion-click",
         label: "<suggestion>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [
+            searchInputCtx,
+            searchResultsCtx,
+            searchResultsSuggestionCtx,
+        ],
     });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ initializeSnowplow("https://commerce.adobedtm.com/sp/v2/sp.js");
 
 configureSnowplow({
     appId: "magento-storefront-event-collector",
-    collectorUrl: "com-magento-qa1.collector.snplow.net",
+    collectorUrl: "com-magento-prod1.mini.snplow.net",
 });
 
 subscribeToEvents();

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7,7 +7,7 @@ const SEARCH_INPUT_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-2";
 
 const SEARCH_RESULTS_SCHEMA_URL =
-    "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-1";
+    "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-3";
 
 const SEARCH_RESULT_PRODUCT_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1";
@@ -16,7 +16,7 @@ const SEARCH_RESULT_CATEGORY_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1";
 
 const SEARCH_RESULT_SUGGESTION_SCHEMA_URL =
-    "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-0";
+    "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1";
 
 export {
     SEARCH_INPUT_SCHEMA_URL,

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -51,7 +51,7 @@ type TrackEventParams = {
     action: string;
     label: string;
     property: string;
-    value: string;
+    value?: number;
     contexts: any[];
 };
 


### PR DESCRIPTION
## Description

Construct Snowplow contexts from the Magento Data Layer.

## Related Issue

[SEARCH-1105](https://jira.corp.magento.com/browse/SEARCH-1105)

## Motivation and Context

Context data is required for proper data modeling in Snowflake.

## How Has This Been Tested?

Tested locally in the `example` directory with the Snowplow Chrome extension.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
