### PR TITLE
SEARCH-1163 | create shopper context

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -2,9 +2,12 @@
     <head>
         <link rel="stylesheet" href="style.css" />
         <script src="https://unpkg.com/@adobe/magento-storefront-events-sdk@0.3.1/dist/index.js"></script>
-        <script src="http://localhost:8080/index.js"></script>
 
         <script>
+            window.magentoStorefrontEvents.context.setShopper({
+                shopperId: "logged-in",
+            });
+
             window.magentoStorefrontEvents.context.setSearchInput({
                 source: "search-bar",
                 query: "red patns",
@@ -57,6 +60,8 @@
                 magentoStorefrontEvents.publish[event.target.value]();
             }
         </script>
+
+        <script src="http://localhost:8080/index.js"></script>
     </head>
 
     <body>

--- a/example/index.html
+++ b/example/index.html
@@ -6,45 +6,50 @@
 
         <script>
             window.magentoStorefrontEvents.context.setSearchInput({
-                searchType: "popover",
+                source: "search-bar",
                 query: "red patns",
+                page: 1,
+                perPage: 20,
                 refinementAttribute: null,
                 refinementSelection: null,
+                sortType: "relevance",
+                sortOrder: "descending",
             });
 
             window.magentoStorefrontEvents.context.setSearchResults({
                 products: [
                     {
-                        title: "Hoodie",
-                        url: "https://magento.com/hoodie",
-                        rank: 1,
-                        resultType: "product",
+                        name: "Red Pants",
                         sku: "abc123",
-                        imageUrl: "https://magento.com/hoodie.jpg",
-                        price: "49.99",
+                        url: "https://magento.com/red-pants",
+                        imageUrl: "https://magento.com/red-pants.jpg",
+                        price: 49.99,
+                        rank: 1,
                     },
                 ],
                 suggestions: [
                     {
-                        title: "Hoodie",
-                        url: "https://magento.com/shirt",
+                        suggestion: "red pants",
                         rank: 1,
-                        resultType: "suggestion",
-                        sku: "abc123",
-                        imageUrl: "https://magento.com/shirt/shirt.jpg",
-                        price: "19.99",
                     },
                 ],
                 categories: [
                     {
-                        title: "Tops",
-                        url: "https://magento.com/tops",
+                        name: "Pants",
+                        url: "https://magento.com/category/pants",
                         rank: 1,
-                        resultType: "category",
+                    },
+                    {
+                        name: "Bottoms",
+                        url: "https://magento.com/category/bottoms",
+                        rank: 2,
                     },
                 ],
                 page: 1,
                 perPage: 20,
+                productCount: 1,
+                categoryCount: 2,
+                suggestionCount: 1,
             });
 
             function fireEvent(event) {

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from "./search";
+export { default as createTrackerCtx } from "./tracker";

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./search";
+export { default as createShopperCtx } from "./shopper";
 export { default as createTrackerCtx } from "./tracker";

--- a/src/contexts/search/index.ts
+++ b/src/contexts/search/index.ts
@@ -3,8 +3,8 @@
  * See COPYING.txt for license details.
  */
 
-export { default as createSearchInputContext } from "./searchInput";
-export { default as createSearchResultCategoryContext } from "./searchResultCategory";
-export { default as createSearchResultProductContext } from "./searchResultProduct";
-export { default as createSearchResultsContext } from "./searchResults";
-export { default as createSearchResultSuggestionContext } from "./searchResultSuggestion";
+export { default as createSearchInputCtx } from "./searchInput";
+export { default as createSearchResultCategoryCtx } from "./searchResultCategory";
+export { default as createSearchResultProductCtx } from "./searchResultProduct";
+export { default as createSearchResultsCtx } from "./searchResults";
+export { default as createSearchResultSuggestionCtx } from "./searchResultSuggestion";

--- a/src/contexts/shopper.ts
+++ b/src/contexts/shopper.ts
@@ -4,15 +4,16 @@
  */
 
 import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
-import pkg from "../../package.json";
+import mse from "@adobe/magento-storefront-events-sdk";
 import schemas from "../schemas";
 
 const createContext = (): Context => {
+    const shopperCtx = mse.context.getShopper();
+
     const context = {
-        schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
+        schema: schemas.SHOPPER_SCHEMA_URL,
         data: {
-            magentoJsVersion: pkg.version,
-            magentoJsBuild: "0000",
+            shopperId: shopperCtx.shopperId,
         },
     };
 

--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -12,6 +12,7 @@ const createContext = (): Context => {
         schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
         data: {
             magentoJsVersion: pkg.version,
+            // TODO: what do we do now that we run off github actions?
             magentoJsBuild: "0000",
         },
     };

--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
+import { version } from "../../package.json";
+import schemas from "../schemas";
+
+const createContext = (): Context => {
+    const context = {
+        schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
+        data: {
+            magentoJsVersion: version,
+            magentoJsBuild: "0000",
+        },
+    };
+
+    return context;
+};
+
+export default createContext;

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -4,16 +4,16 @@
  */
 
 import {
-    createSearchInputContext,
-    createSearchResultsContext,
-    createSearchResultSuggestionContext,
+    createSearchInputCtx,
+    createSearchResultsCtx,
+    createSearchResultSuggestionCtx,
 } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
-    const searchResultsCtx = createSearchResultsContext();
-    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
+    const searchInputCtx = createSearchInputCtx();
+    const searchResultsCtx = createSearchResultsCtx();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionCtx();
 
     trackEvent({
         category: "search",

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -3,16 +3,28 @@
  * See COPYING.txt for license details.
  */
 
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+    createSearchResultSuggestionContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
+
     trackEvent({
         category: "search",
         action: "category-click",
         label: "<categoryUrlKey>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [
+            searchInputCtx,
+            searchResultsCtx,
+            searchResultsSuggestionCtx,
+        ],
     });
 };
 

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -3,20 +3,24 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultProductContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsProductCtx = createSearchResultProductContext();
 
     trackEvent({
         category: "search",
         action: "product-click",
         label: "<sku>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx, searchResultsProductCtx],
     });
 };
 

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -4,16 +4,16 @@
  */
 
 import {
-    createSearchInputContext,
-    createSearchResultProductContext,
-    createSearchResultsContext,
+    createSearchInputCtx,
+    createSearchResultProductCtx,
+    createSearchResultsCtx,
 } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
-    const searchResultsCtx = createSearchResultsContext();
-    const searchResultsProductCtx = createSearchResultProductContext();
+    const searchInputCtx = createSearchInputCtx();
+    const searchResultsCtx = createSearchResultsCtx();
+    const searchResultsProductCtx = createSearchResultProductCtx();
 
     trackEvent({
         category: "search",

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -3,11 +3,11 @@
  * See COPYING.txt for license details.
  */
 
-import { createSearchInputContext } from "../../contexts";
+import { createSearchInputCtx } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
+    const searchInputCtx = createSearchInputCtx();
 
     trackEvent({
         category: "search",

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -3,19 +3,18 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import { createSearchInputContext } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
+    const searchInputCtx = createSearchInputContext();
 
     trackEvent({
         category: "search",
         action: "api-request-sent",
         label: "<query>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx],
     });
 };
 

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -3,19 +3,22 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
 
     trackEvent({
         category: "search",
         action: "api-response-received",
         label: "<query>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx],
     });
 };
 

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -3,15 +3,12 @@
  * See COPYING.txt for license details.
  */
 
-import {
-    createSearchInputContext,
-    createSearchResultsContext,
-} from "../../contexts";
+import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
-    const searchResultsCtx = createSearchResultsContext();
+    const searchInputCtx = createSearchInputCtx();
+    const searchResultsCtx = createSearchResultsCtx();
 
     trackEvent({
         category: "search",

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -3,15 +3,12 @@
  * See COPYING.txt for license details.
  */
 
-import {
-    createSearchInputContext,
-    createSearchResultsContext,
-} from "../../contexts";
+import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
-    const searchResultsCtx = createSearchResultsContext();
+    const searchInputCtx = createSearchInputCtx();
+    const searchResultsCtx = createSearchResultsCtx();
 
     trackEvent({
         category: "search",

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -3,20 +3,22 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
 
     trackEvent({
         category: "search",
         action: "results-view",
         label: "",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [searchInputCtx, searchResultsCtx],
     });
 };
 

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -3,20 +3,28 @@
  * See COPYING.txt for license details.
  */
 
-import mse from "@adobe/magento-storefront-events-sdk";
+import {
+    createSearchInputContext,
+    createSearchResultsContext,
+    createSearchResultSuggestionContext,
+} from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = mse.context.getSearchInput();
-    const searchResultsCtx = mse.context.getSearchResults();
+    const searchInputCtx = createSearchInputContext();
+    const searchResultsCtx = createSearchResultsContext();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
 
     trackEvent({
         category: "search",
         action: "suggestion-click",
         label: "<suggestion>",
         property: "<pageType>",
-        value: "<search-bar | results-page | other>",
-        contexts: [],
+        contexts: [
+            searchInputCtx,
+            searchResultsCtx,
+            searchResultsSuggestionCtx,
+        ],
     });
 };
 

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -4,16 +4,16 @@
  */
 
 import {
-    createSearchInputContext,
-    createSearchResultsContext,
-    createSearchResultSuggestionContext,
+    createSearchInputCtx,
+    createSearchResultsCtx,
+    createSearchResultSuggestionCtx,
 } from "../../contexts";
 import { trackEvent } from "../../snowplow";
 
 const handler = (): void => {
-    const searchInputCtx = createSearchInputContext();
-    const searchResultsCtx = createSearchResultsContext();
-    const searchResultsSuggestionCtx = createSearchResultSuggestionContext();
+    const searchInputCtx = createSearchInputCtx();
+    const searchResultsCtx = createSearchResultsCtx();
+    const searchResultsSuggestionCtx = createSearchResultSuggestionCtx();
 
     trackEvent({
         category: "search",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ initializeSnowplow("https://commerce.adobedtm.com/sp/v2/sp.js");
 
 configureSnowplow({
     appId: "magento-storefront-event-collector",
-    collectorUrl: "com-magento-qa1.collector.snplow.net",
+    collectorUrl: "com-magento-prod1.mini.snplow.net",
 });
 
 subscribeToEvents();

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4,14 +4,16 @@
  */
 
 const schemas = {
+    MAGENTO_JS_TRACKER_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/1-0-0",
     SEARCH_INPUT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-2",
-    SEARCH_RESULTS_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-3",
-    SEARCH_RESULT_PRODUCT_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1",
     SEARCH_RESULT_CATEGORY_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1",
+    SEARCH_RESULT_PRODUCT_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1",
+    SEARCH_RESULTS_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-3",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -16,6 +16,8 @@ const schemas = {
         "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-3",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
+    SHOPPER_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/shopper/jsonschema/1-0-0",
 };
 
 export default schemas;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7,7 +7,7 @@ const SEARCH_INPUT_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-2";
 
 const SEARCH_RESULTS_SCHEMA_URL =
-    "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-1";
+    "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-3";
 
 const SEARCH_RESULT_PRODUCT_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1";
@@ -16,7 +16,7 @@ const SEARCH_RESULT_CATEGORY_SCHEMA_URL =
     "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1";
 
 const SEARCH_RESULT_SUGGESTION_SCHEMA_URL =
-    "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-0";
+    "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1";
 
 export {
     SEARCH_INPUT_SCHEMA_URL,

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { createTrackerCtx } from "./contexts";
+import { createTrackerCtx, createShopperCtx } from "./contexts";
 import { plowing } from "./plowing";
 
 const initializeSnowplow = (spUrl: string): void => {
@@ -47,8 +47,9 @@ const configureSnowplow = ({
     });
 
     const trackerCtx = createTrackerCtx();
+    const shopperCtx = createShopperCtx();
 
-    window.snowplow("addGlobalContexts", [trackerCtx]);
+    window.snowplow("addGlobalContexts", [trackerCtx, shopperCtx]);
 };
 
 type TrackEventParams = {

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -3,6 +3,7 @@
  * See COPYING.txt for license details.
  */
 
+import { createTrackerCtx } from "./contexts";
 import { plowing } from "./plowing";
 
 const initializeSnowplow = (spUrl: string): void => {
@@ -36,7 +37,7 @@ const configureSnowplow = ({
         crossDomainLinker: null,
         cookieLifetime: 86400 * 365 * 2,
         stateStorageStrategy: "localStorage",
-        postPath: "/collector/tp2",
+        // postPath: "/collector/tp2",
         contexts: {
             webPage: true,
             performanceTiming: true,
@@ -44,6 +45,10 @@ const configureSnowplow = ({
             geolocation: false,
         },
     });
+
+    const trackerCtx = createTrackerCtx();
+
+    window.snowplow("addGlobalContexts", [trackerCtx]);
 };
 
 type TrackEventParams = {

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -51,7 +51,7 @@ type TrackEventParams = {
     action: string;
     label: string;
     property: string;
-    value: string;
+    value?: number;
     contexts: any[];
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "strict": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "resolveJsonModule": true
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## Description

Creates the shopper context from the Magento Storefront Events SDK data, and included it in global contexts.

## Related Issue

[SEARCH-1163](https://jira.corp.magento.com/browse/SEARCH-1163)

## Motivation and Context

We need to support the same global contexts as our existing tracker.

## How Has This Been Tested?

Locally with the `example` directory, monitoring events with the Snowplow Chrome extension and Kibana.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
