### PR TITLE
SEARCH-1162 | create magento extension context

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,6 +4,10 @@
         <script src="https://unpkg.com/@adobe/magento-storefront-events-sdk@0.3.1/dist/index.js"></script>
 
         <script>
+            window.magentoStorefrontEvents.context.setMagentoExtension({
+                magentoExtensionVersion: "1.2.3",
+            });
+
             window.magentoStorefrontEvents.context.setStorefrontInstance({
                 baseCurrencyCode: "USD",
                 storeViewCurrencyCode: "USD",

--- a/src/contexts/extension.ts
+++ b/src/contexts/extension.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
+import mse from "@adobe/magento-storefront-events-sdk";
+import schemas from "../schemas";
+
+const createContext = (): Context => {
+    const magentoExtensionCtx = mse.context.getMagentoExtension();
+
+    const context = {
+        schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
+        data: {
+            magentoExtensionVersion:
+                magentoExtensionCtx.magentoExtensionVersion,
+        },
+    };
+
+    return context;
+};
+
+export default createContext;

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -7,3 +7,4 @@ export * from "./search";
 export { default as createShopperCtx } from "./shopper";
 export { default as createStorefrontInstanceCtx } from "./storefrontInstance";
 export { default as createTrackerCtx } from "./tracker";
+export { default as createMagentoExtensionCtx } from "./extension";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4,6 +4,8 @@
  */
 
 const schemas = {
+    MAGENTO_EXTENSION_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/magento-extension/jsonschema/1-0-0",
     MAGENTO_JS_TRACKER_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/1-0-0",
     SEARCH_INPUT_SCHEMA_URL:

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -7,6 +7,7 @@ import {
     createTrackerCtx,
     createShopperCtx,
     createStorefrontInstanceCtx,
+    createMagentoExtensionCtx,
 } from "./contexts";
 import { plowing } from "./plowing";
 
@@ -50,11 +51,13 @@ const configureSnowplow = ({
         },
     });
 
+    const magentoExtensionCtx = createMagentoExtensionCtx();
     const trackerCtx = createTrackerCtx();
     const shopperCtx = createShopperCtx();
     const storefrontInstanceCtx = createStorefrontInstanceCtx();
 
     window.snowplow("addGlobalContexts", [
+        magentoExtensionCtx,
         trackerCtx,
         shopperCtx,
         storefrontInstanceCtx,


### PR DESCRIPTION
## Description

Create the `magentoExtension` context and include it in the array of global contexts.

## Related Issue

[SEARCH-1162](https://jira.corp.magento.com/browse/SEARCH-1162)

## Motivation and Context

We need to align the global contexts with the old tracker.

## How Has This Been Tested?

Tested locally with the `example` directory, monitoring events with the Snowplow Chrome extension and Kibana.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
