### PR TITLE
chore: add type definitions to contexts

### DIFF
--- a/src/contexts/extension.ts
+++ b/src/contexts/extension.ts
@@ -4,11 +4,10 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../schemas";
 
-const createContext = (): Context => {
+const createContext = (): ExtensionContext => {
     const magentoExtensionCtx = mse.context.getMagentoExtension();
 
     const context = {

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -8,5 +8,5 @@ export { default as createProductCtx } from "./product";
 export * from "./search";
 export { default as createShopperCtx } from "./shopper";
 export { default as createShoppingCartCtx } from "./shoppingCart";
-export { default as createStorefrontInstanceCtx } from "./storefrontInstance";
+export { default as createStorefrontInstanceCtx } from "./storefront";
 export { default as createTrackerCtx } from "./tracker";

--- a/src/contexts/product.ts
+++ b/src/contexts/product.ts
@@ -15,7 +15,7 @@ const createContext = (): ProductContext => {
         data: {
             productId: productCtx.productId,
             name: productCtx.name,
-            sku: productCtx.sku,
+            sku: productCtx.sku ?? "",
             topLevelSku: productCtx.topLevelSku,
             specialToDate: productCtx.specialToDate,
             specialFromDate: productCtx.specialFromDate,
@@ -28,16 +28,17 @@ const createContext = (): ProductContext => {
             categories: productCtx.categories,
             productType: productCtx.productType,
             pricing: {
-                regularPrice: productCtx.pricing?.regularPrice,
-                minimalPrice: productCtx.pricing?.minimalPrice,
-                maximalPrice: productCtx.pricing?.maximalPrice,
+                // TODO: what happens when these are undefined?
+                regularPrice: productCtx.pricing?.regularPrice ?? 0,
+                minimalPrice: productCtx.pricing?.minimalPrice ?? 0,
+                maximalPrice: productCtx.pricing?.maximalPrice ?? 0,
                 specialPrice: productCtx.pricing?.specialPrice,
                 tierPricing: productCtx.pricing?.tierPricing.map(price => ({
-                    customerGroupId: price.customerGroupId,
+                    customerGroupId: price.customerGroupId ?? null,
                     qty: price.qty,
                     value: price.value,
                 })),
-                currencyCode: productCtx.pricing?.currencyCode,
+                currencyCode: productCtx.pricing?.currencyCode ?? null,
             },
             canonicalUrl: productCtx.canonicalUrl,
             mainImageUrl: productCtx.mainImageUrl,

--- a/src/contexts/product.ts
+++ b/src/contexts/product.ts
@@ -4,11 +4,10 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../schemas";
 
-const createContext = (): Context => {
+const createContext = (): ProductContext => {
     const productCtx = mse.context.getProduct();
 
     const context = {

--- a/src/contexts/search/searchInput.ts
+++ b/src/contexts/search/searchInput.ts
@@ -13,7 +13,7 @@ const createContext = (): SearchInputContext => {
     const context = {
         schema: schemas.SEARCH_INPUT_SCHEMA_URL,
         data: {
-            source: searchInputCtx.source,
+            source: searchInputCtx.source ?? undefined,
             query: searchInputCtx.query,
             page: searchInputCtx.page,
             perPage: searchInputCtx.perPage,

--- a/src/contexts/search/searchInput.ts
+++ b/src/contexts/search/searchInput.ts
@@ -4,24 +4,23 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../../schemas";
 
-const createContext = (): Context => {
-    const searchInput = mse.context.getSearchInput();
+const createContext = (): SearchInputContext => {
+    const searchInputCtx = mse.context.getSearchInput();
 
     const context = {
         schema: schemas.SEARCH_INPUT_SCHEMA_URL,
         data: {
-            source: searchInput.source,
-            query: searchInput.query,
-            page: searchInput.page,
-            perPage: searchInput.perPage,
-            refinementAttribute: searchInput.refinementAttribute,
-            refinementSelection: searchInput.refinementSelection,
-            sortType: searchInput.sortType,
-            sortOrder: searchInput.sortOrder,
+            source: searchInputCtx.source,
+            query: searchInputCtx.query,
+            page: searchInputCtx.page,
+            perPage: searchInputCtx.perPage,
+            refinementAttribute: searchInputCtx.refinementAttribute,
+            refinementSelection: searchInputCtx.refinementSelection,
+            sortType: searchInputCtx.sortType,
+            sortOrder: searchInputCtx.sortOrder,
         },
     };
 

--- a/src/contexts/search/searchResultCategory.ts
+++ b/src/contexts/search/searchResultCategory.ts
@@ -4,13 +4,12 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../../schemas";
 
-const createContext = (): Context => {
-    const searchResults = mse.context.getSearchResults();
-    const category = searchResults.categories[0];
+const createContext = (): SearchResultCategoryContext => {
+    const searchResultsCtx = mse.context.getSearchResults();
+    const category = searchResultsCtx.categories[0];
 
     const context = {
         schema: schemas.SEARCH_RESULT_CATEGORY_SCHEMA_URL,

--- a/src/contexts/search/searchResultProduct.ts
+++ b/src/contexts/search/searchResultProduct.ts
@@ -4,13 +4,12 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../../schemas";
 
-const createContext = (): Context => {
-    const searchResults = mse.context.getSearchResults();
-    const product = searchResults.products[0];
+const createContext = (): SearchResultProductContext => {
+    const searchResultsCtx = mse.context.getSearchResults();
+    const product = searchResultsCtx.products[0];
 
     const context = {
         schema: schemas.SEARCH_RESULT_PRODUCT_SCHEMA_URL,

--- a/src/contexts/search/searchResultSuggestion.ts
+++ b/src/contexts/search/searchResultSuggestion.ts
@@ -4,13 +4,12 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../../schemas";
 
-const createContext = (): Context => {
-    const searchResults = mse.context.getSearchResults();
-    const suggestion = searchResults.suggestions[0];
+const createContext = (): SearchResultSuggestionContext => {
+    const searchResultsCtx = mse.context.getSearchResults();
+    const suggestion = searchResultsCtx.suggestions[0];
 
     const context = {
         schema: schemas.SEARCH_RESULT_SUGGESTION_SCHEMA_URL,

--- a/src/contexts/search/searchResults.ts
+++ b/src/contexts/search/searchResults.ts
@@ -4,24 +4,23 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../../schemas";
 
-const createContext = (): Context => {
-    const searchResults = mse.context.getSearchResults();
+const createContext = (): SearchResultsContext => {
+    const searchResultsCtx = mse.context.getSearchResults();
 
     const context = {
         schema: schemas.SEARCH_RESULTS_SCHEMA_URL,
         data: {
-            products: searchResults.products,
-            categories: searchResults.categories,
-            suggestions: searchResults.suggestions,
-            productCount: searchResults.productCount,
-            categoryCount: searchResults.categoryCount,
-            suggestionCount: searchResults.suggestionCount,
-            page: searchResults.page,
-            perPage: searchResults.perPage,
+            products: searchResultsCtx.products,
+            categories: searchResultsCtx.categories,
+            suggestions: searchResultsCtx.suggestions,
+            productCount: searchResultsCtx.productCount,
+            categoryCount: searchResultsCtx.categoryCount,
+            suggestionCount: searchResultsCtx.suggestionCount,
+            page: searchResultsCtx.page,
+            perPage: searchResultsCtx.perPage,
         },
     };
 

--- a/src/contexts/shopper.ts
+++ b/src/contexts/shopper.ts
@@ -4,11 +4,10 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../schemas";
 
-const createContext = (): Context => {
+const createContext = (): ShopperContext => {
     const shopperCtx = mse.context.getShopper();
 
     const context = {

--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -18,12 +18,14 @@ const createShoppingCartItems = () => {
         basePrice: item.product.pricing?.regularPrice,
         // TODO: how do we reconcile string to int
         cartItemId: parseInt(item.id) || 0,
-        mainImageUrl: item.product.mainImageUrl,
+        mainImageUrl: item.product.mainImageUrl ?? undefined,
         // TODO: what price should we use?
-        offerPrice: item.prices?.[0].value,
+        offerPrice: item.prices?.[0].value ?? 0,
         productName: item.product.name,
-        productSku: item.product.sku,
-        qty: item.quantity,
+        // TODO: what happens if its undefined?
+        productSku: item.product.sku ?? "",
+        // TODO: what happens if its undefined?
+        qty: item.quantity ?? 0,
     }));
 
     return shoppingCartItems;

--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -4,7 +4,6 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../schemas";
 
@@ -30,7 +29,7 @@ const createShoppingCartItems = () => {
     return shoppingCartItems;
 };
 
-const createContext = (): Context => {
+const createContext = (): ShoppingCartContext => {
     const shoppingCartCtx = mse.context.getShoppingCart();
     const orderCtx = mse.context.getOrder();
 

--- a/src/contexts/storefront.ts
+++ b/src/contexts/storefront.ts
@@ -4,11 +4,10 @@
  */
 
 import mse from "@adobe/magento-storefront-events-sdk";
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
 
 import schemas from "../schemas";
 
-const createContext = (): Context => {
+const createContext = (): StorefrontContext => {
     const storefrontInstanceCtx = mse.context.getStorefrontInstance();
 
     const context = {

--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -3,12 +3,10 @@
  * See COPYING.txt for license details.
  */
 
-import { Context } from "@adobe/magento-storefront-events-sdk/dist/types/types/contexts";
-
 import pkg from "../../package.json";
 import schemas from "../schemas";
 
-const createContext = (): Context => {
+const createContext = (): TrackerContext => {
     const context = {
         schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
         data: {

--- a/src/handlers/addToCart.ts
+++ b/src/handlers/addToCart.ts
@@ -12,7 +12,6 @@ const handler = (): void => {
     trackEvent({
         category: "product",
         action: "add-to-cart",
-        label: "",
         property: "<pageType>",
         contexts: [productCtx],
     });

--- a/src/handlers/placeOrder.ts
+++ b/src/handlers/placeOrder.ts
@@ -14,7 +14,6 @@ const handler = (): void => {
         // TODO: this should be the cartId, which is a string,
         //       but Snowplow expects a number for value.
         value: 0,
-        contexts: [],
     });
 };
 

--- a/src/handlers/productView.ts
+++ b/src/handlers/productView.ts
@@ -12,7 +12,6 @@ const handler = (): void => {
     trackEvent({
         category: "product",
         action: "view",
-        label: "",
         property: "<pageType>",
         contexts: [productCtx],
     });

--- a/src/handlers/recommendations/recsRequestSent.ts
+++ b/src/handlers/recommendations/recsRequestSent.ts
@@ -9,9 +9,7 @@ const handler = (): void => {
     trackEvent({
         category: "recommendation-unit",
         action: "api-request-sent",
-        label: "",
         property: "<pageType>",
-        contexts: [],
     });
 };
 

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -13,7 +13,6 @@ const handler = (): void => {
     trackEvent({
         category: "search",
         action: "results-view",
-        label: "",
         property: "<pageType>",
         contexts: [searchInputCtx, searchResultsCtx],
     });

--- a/src/handlers/shoppingCartView.ts
+++ b/src/handlers/shoppingCartView.ts
@@ -9,12 +9,10 @@ const handler = (): void => {
     trackEvent({
         category: "shopping-cart",
         action: "view",
-        label: "",
         property: "<pageType>",
         // TODO: this should be the cartId, which is a string,
         //       but Snowplow expects a number for value.
         value: 0,
-        contexts: [],
     });
 };
 

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -70,10 +70,10 @@ const configureSnowplow = ({
 type TrackEventParams = {
     category: string;
     action: string;
-    label: string;
-    property: string;
+    label?: string;
+    property?: string;
     value?: number;
-    contexts: unknown[];
+    contexts?: unknown[];
 };
 
 const trackEvent = ({

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -73,7 +73,7 @@ type TrackEventParams = {
     label?: string;
     property?: string;
     value?: number;
-    contexts?: unknown[];
+    contexts?: Array<SnowplowContext>;
 };
 
 const trackEvent = ({

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -1,0 +1,196 @@
+type Extension = {
+    magentoExtensionVersion: string;
+};
+
+type Product = {
+    canonicalUrl?: string | null;
+    categories?: Array<string | null>;
+    countryOfManufacture?: string | null;
+    createdAt?: string | null;
+    mainImageUrl?: string | null;
+    manufacturer?: string | null;
+    name: string;
+    newFromDate?: string | null;
+    newToDate?: string | null;
+    productId: number;
+    sku: string;
+    pricing?: {
+        currencyCode: string | null;
+        maximalPrice: number;
+        minimalPrice: number;
+        regularPrice: number;
+        specialPrice?: number;
+        tierPricing?: Array<{
+            customerGroupId: number | null;
+            qty: number;
+            value: number;
+        }>;
+    };
+    productType?: string | null;
+    specialFromDate?: string | null;
+    specialToDate?: string | null;
+    topLevelSku?: string | null;
+    updatedAt?: string | null;
+};
+
+type SearchInput = {
+    page: number;
+    perPage: number;
+    query: string;
+    refinements?: Array<{
+        name?: string;
+        value?: string;
+    }>;
+    sortType: string;
+    sortOrder: string;
+    source?: string;
+};
+
+type SearchResultCategory = {
+    name: string;
+    rank: number;
+    url: string;
+};
+
+type SearchResultProduct = {
+    imageUrl: string;
+    name: string;
+    price: number;
+    rank: number;
+    sku: string;
+    url: string;
+};
+
+type SearchResults = {
+    products: Array<SearchResultProduct>;
+    suggestions: Array<SearchResultSuggestion>;
+    categories: Array<SearchResultCategory>;
+    page: number;
+    perPage: number;
+    productCount: number;
+    categoryCount: number;
+    suggestionCount: number;
+};
+
+type SearchResultSuggestion = {
+    suggestion: string;
+    rank: number;
+};
+
+type Shopper = {
+    ecid?: string;
+    name?: string;
+    shopperId: string;
+};
+
+type ShoppingCart = {
+    cartId?: number | null;
+    giftMessageSelected?: boolean;
+    giftWrappingSelected?: boolean;
+    items?: Array<{
+        basePrice?: number;
+        cartItemId: number;
+        mainImageUrl?: string;
+        offerPrice: number;
+        productName: string;
+        productSku: string;
+        qty: number;
+    }>;
+    itemsCount: number;
+    possibleOnepageCheckout?: boolean;
+    subtotalAmount?: number;
+    subtotalExcludingTax?: number;
+    subtotalIncludingTax?: number;
+};
+
+type Storefront = {
+    baseCurrencyCode: string;
+    catalogExtensionVersion?: string | null;
+    environment: string;
+    environmentId: string;
+    instanceId?: string;
+    storeCode?: string;
+    storeId: number;
+    storeName: string;
+    storeUrl: string;
+    storeViewCode?: string;
+    storeViewCurrencyCode: string;
+    storeViewId: number;
+    storeViewName: string;
+    websiteCode?: string;
+    websiteId: number;
+    websiteName: string;
+};
+
+type Tracker = {
+    magentoJsVersion: string;
+    magentoJsBuild: string;
+};
+
+type ExtensionContext = {
+    schema: string;
+    data: Extension;
+};
+
+type ProductContext = {
+    schema: string;
+    data: Product;
+};
+
+type SearchInputContext = {
+    schema: string;
+    data: SearchInput;
+};
+
+type SearchResultCategoryContext = {
+    schema: string;
+    data: SearchResultCategory;
+};
+
+type SearchResultProductContext = {
+    schema: string;
+    data: SearchResultProduct;
+};
+
+type SearchResultsContext = {
+    schema: string;
+    data: SearchResults;
+};
+
+type SearchResultSuggestionContext = {
+    schema: string;
+    data: SearchResultSuggestion;
+};
+
+type ShopperContext = {
+    schema: string;
+    data: Shopper;
+};
+
+type ShoppingCartContext = {
+    schema: string;
+    data: ShoppingCart;
+};
+
+type StorefrontContext = {
+    schema: string;
+    data: Storefront;
+};
+
+type TrackerContext = {
+    schema: string;
+    data: Tracker;
+};
+
+type SnowplowContext =
+    | ExtensionContext
+    | ProductContext
+    | SearchInputContext
+    | SearchResultCategoryContext
+    | SearchResultProductContext
+    | SearchResultsContext
+    | SearchResultSuggestionContext
+    | ShopperContext
+    | ShoppingCartContext
+    | StorefrontContext
+    | TrackerContext;

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -4,7 +4,7 @@ type Extension = {
 
 type Product = {
     canonicalUrl?: string | null;
-    categories?: Array<string | null>;
+    categories?: Array<string> | null;
     countryOfManufacture?: string | null;
     createdAt?: string | null;
     mainImageUrl?: string | null;


### PR DESCRIPTION
## Description

Add type definitions for all contexts and apply them to the context creators.

## Related Issue

N/A

## Motivation and Context

Doing our best to keep everything fully typed from the SDK to the collector to the Snowplow schemas.

## How Has This Been Tested?

Tested locally with the `example` directory, monitoring events through the Snowplow Chrome extension and in Kibana.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
