### PR TITLE
SEARCH-1374 | search request id

### DIFF
--- a/src/contexts/search/searchInput.ts
+++ b/src/contexts/search/searchInput.ts
@@ -17,7 +17,7 @@ const createContext = (searchInput?: SearchInput): SearchInputContext => {
         data: {
             source: searchInputCtx.source ?? null,
             queryType: "all",
-            searchRequestId: "abc123",
+            searchRequestId: searchInputCtx.searchRequestId,
             query: searchInputCtx.query,
             page: searchInputCtx.page,
             perPage: searchInputCtx.perPage,

--- a/src/contexts/search/searchResults.ts
+++ b/src/contexts/search/searchResults.ts
@@ -14,7 +14,7 @@ const createContext = (searchResults?: SearchResults): SearchResultsContext => {
     const context = {
         schema: schemas.SEARCH_RESULTS_SCHEMA_URL,
         data: {
-            searchRequestId: "abc123",
+            searchRequestId: searchResultsCtx.searchRequestId,
             products: searchResultsCtx.products,
             categories: searchResultsCtx.categories,
             suggestions: searchResultsCtx.suggestions,

--- a/tests/utils/mocks/dataLayer.ts
+++ b/tests/utils/mocks/dataLayer.ts
@@ -252,6 +252,7 @@ const mockShopper: Shopper = {
 };
 
 const mockSearchInput: SearchInput = {
+    searchRequestId: "abc123",
     source: "search-bar",
     query: "red patns",
     page: 1,
@@ -275,6 +276,7 @@ const mockSearchInput: SearchInput = {
 };
 
 const mockSearchResults: SearchResults = {
+    searchRequestId: "abc123",
     products: [
         {
             name: "Red Pants",


### PR DESCRIPTION
## Description

Include `searchRequestId` in the Snowplow context.

## Related Issue

[SEARCH-1374](https://jira.corp.magento.com/browse/SEARCH-1374)

## Motivation and Context

Required to link requests and responses together in data modeling.

## How Has This Been Tested?

Tested with `jest` and the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
