### PR TITLE
SEARCH-1413 | instant purchase event handler

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,120 +9,97 @@
 
     <body>
         <div class="events">
-            <button
-                value="addToCart"
-                onclick="magentoStorefrontEvents.publish.addToCart()"
-            >
+            <button onclick="magentoStorefrontEvents.publish.addToCart()">
                 addToCart
             </button>
 
-            <button
-                value="pageView"
-                onclick="magentoStorefrontEvents.publish.pageView()"
-            >
+            <button onclick="magentoStorefrontEvents.publish.instantPurchase()">
+                instantPurchase
+            </button>
+
+            <button onclick="magentoStorefrontEvents.publish.pageView()">
                 pageView
             </button>
 
-            <button
-                value="placeOrder"
-                onclick="magentoStorefrontEvents.publish.placeOrder()"
-            >
+            <button onclick="magentoStorefrontEvents.publish.placeOrder()">
                 placeOrder
             </button>
 
-            <button
-                value="productPageView"
-                onclick="magentoStorefrontEvents.publish.productPageView()"
-            >
+            <button onclick="magentoStorefrontEvents.publish.productPageView()">
                 productPageView
             </button>
 
             <button
-                value="recsItemAddToCartClick"
                 onclick="magentoStorefrontEvents.publish.recsItemAddToCartClick('abc123', 111111)"
             >
                 recsItemAddToCartClick
             </button>
 
             <button
-                value="recsItemClick"
                 onclick="magentoStorefrontEvents.publish.recsItemClick('abc123', 111111)"
             >
                 recsItemClick
             </button>
 
-            <button
-                value="recsRequestSent"
-                onclick="magentoStorefrontEvents.publish.recsRequestSent()"
-            >
+            <button onclick="magentoStorefrontEvents.publish.recsRequestSent()">
                 recsRequestSent
             </button>
 
             <button
-                value="recsResponseReceived"
                 onclick="magentoStorefrontEvents.publish.recsResponseReceived()"
             >
                 recsResponseReceived
             </button>
 
             <button
-                value="recsUnitRender"
                 onclick="magentoStorefrontEvents.publish.recsUnitRender('abc123')"
             >
                 recsUnitRender
             </button>
 
             <button
-                value="recsUnitView"
                 onclick="magentoStorefrontEvents.publish.recsUnitView('abc123')"
             >
                 recsUnitView
             </button>
 
             <button
-                value="searchCategoryClick"
                 onclick="magentoStorefrontEvents.publish.searchCategoryClick('Bottoms')"
             >
                 searchCategoryClick
             </button>
 
             <button
-                value="searchProductClick"
                 onclick="magentoStorefrontEvents.publish.searchProductClick('abc123')"
             >
                 searchProductClick
             </button>
 
             <button
-                value="searchRequestSent"
                 onclick="magentoStorefrontEvents.publish.searchRequestSent()"
             >
                 searchRequestSent
             </button>
 
             <button
-                value="searchResponseReceived"
                 onclick="magentoStorefrontEvents.publish.searchResponseReceived()"
             >
                 searchResponseReceived
             </button>
 
             <button
-                value="searchResultsView"
                 onclick="magentoStorefrontEvents.publish.searchResultsView()"
             >
                 searchResultsView
             </button>
 
             <button
-                value="searchSuggestionClick"
                 onclick="magentoStorefrontEvents.publish.searchSuggestionClick('red pants')"
             >
                 searchSuggestionClick
             </button>
 
             <button
-                value="shoppingCartView"
                 onclick="magentoStorefrontEvents.publish.shoppingCartView()"
             >
                 shoppingCartView

--- a/src/events.ts
+++ b/src/events.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 
 import {
     addToCartHandler,
+    instantPurchaseHandler,
     pageViewHandler,
     placeOrderHandler,
     productViewHandler,
@@ -27,6 +28,7 @@ import {
 
 const subscribeToEvents = (): void => {
     mse.subscribe.addToCart(addToCartHandler);
+    mse.subscribe.instantPurchase(instantPurchaseHandler);
     mse.subscribe.pageView(pageViewHandler);
     mse.subscribe.placeOrder(placeOrderHandler);
     mse.subscribe.productPageView(productViewHandler);
@@ -47,6 +49,7 @@ const subscribeToEvents = (): void => {
 
 const unsubscribeFromEvents = (): void => {
     mse.unsubscribe.addToCart(addToCartHandler);
+    mse.subscribe.instantPurchase(instantPurchaseHandler);
     mse.unsubscribe.pageView(pageViewHandler);
     mse.unsubscribe.placeOrder(placeOrderHandler);
     mse.unsubscribe.productPageView(productViewHandler);

--- a/src/handlers/checkout/index.ts
+++ b/src/handlers/checkout/index.ts
@@ -3,4 +3,5 @@
  * See COPYING.txt for license details.
  */
 
+export { default as instantPurchaseHandler } from "./instantPurchase";
 export { default as placeOrderHandler } from "./placeOrder";

--- a/src/handlers/checkout/instantPurchase.ts
+++ b/src/handlers/checkout/instantPurchase.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
+import { trackStructEvent } from "@snowplow/browser-tracker";
+
+import { createProductCtx, createShoppingCartCtx } from "../../contexts";
+
+const handler = (event: Event): void => {
+    const {
+        pageContext,
+        orderContext,
+        productContext,
+        shoppingCartContext,
+    } = event.eventInfo;
+
+    const productCtx = createProductCtx(productContext);
+    const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
+
+    trackStructEvent({
+        category: "checkout",
+        action: "instant-purchase",
+        label: orderContext.orderId.toString(),
+        property: pageContext.pageType,
+        context: [productCtx, shoppingCartCtx],
+    });
+};
+
+export default handler;

--- a/tests/contexts/global.test.ts
+++ b/tests/contexts/global.test.ts
@@ -3,7 +3,6 @@ import schemas from "../../src/schemas";
 import {
     mockExtensionCtx,
     mockShopperCtx,
-    mockShoppingCartCtx,
     mockStorefrontCtx,
     mockTrackerCtx,
 } from "../utils/mocks";

--- a/tests/handlers/checkout/instantPurchase.test.ts
+++ b/tests/handlers/checkout/instantPurchase.test.ts
@@ -4,8 +4,6 @@ import { instantPurchaseHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
 import {
     mockEvent,
-    mockOrder,
-    mockPage,
     mockProductCtx,
     mockShoppingCartCtx,
 } from "../../utils/mocks";

--- a/tests/handlers/checkout/instantPurchase.test.ts
+++ b/tests/handlers/checkout/instantPurchase.test.ts
@@ -1,0 +1,34 @@
+import { trackStructEvent } from "@snowplow/browser-tracker";
+
+import { instantPurchaseHandler } from "../../../src/handlers";
+import schemas from "../../../src/schemas";
+import {
+    mockEvent,
+    mockOrder,
+    mockPage,
+    mockProductCtx,
+    mockShoppingCartCtx,
+} from "../../utils/mocks";
+
+test("sends snowplow event", () => {
+    instantPurchaseHandler(mockEvent);
+
+    expect(trackStructEvent).toHaveBeenCalledTimes(1);
+
+    expect(trackStructEvent).toHaveBeenCalledWith({
+        category: "checkout",
+        action: "instant-purchase",
+        label: "111111",
+        property: "pdp",
+        context: [
+            {
+                data: mockProductCtx,
+                schema: schemas.PRODUCT_SCHEMA_URL,
+            },
+            {
+                data: mockShoppingCartCtx,
+                schema: schemas.SHOPPING_CART_SCHEMA_URL,
+            },
+        ],
+    });
+});


### PR DESCRIPTION
## Description

Add the `InstantPurchase` event handler.

## Related Issue

[SEARCH-1413](https://jira.corp.magento.com/browse/SEARCH-1413)

## Motivation and Context

The `SDK` has the ability to publish the `InstantPurchase` event, but the collector did not have an associated handler.

## How Has This Been Tested?

Tested with `jest` as well as the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
