### PR TITLE
SEARCH-1382 | handle empty shopping cart

### DIFF
--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -36,8 +36,14 @@ const createShoppingCartItems = (shoppingCart?: ShoppingCart) => {
     return shoppingCartItems;
 };
 
-const createContext = (shoppingCart?: ShoppingCart): ShoppingCartContext => {
+const createContext = (
+    shoppingCart?: ShoppingCart,
+): ShoppingCartContext | null => {
     const shoppingCartCtx = shoppingCart ?? mse.context.getShoppingCart();
+
+    if (!shoppingCartCtx) {
+        return null;
+    }
 
     const context = {
         schema: schemas.SHOPPING_CART_SCHEMA_URL,

--- a/src/events.ts
+++ b/src/events.ts
@@ -49,7 +49,7 @@ const subscribeToEvents = (): void => {
 
 const unsubscribeFromEvents = (): void => {
     mse.unsubscribe.addToCart(addToCartHandler);
-    mse.subscribe.instantPurchase(instantPurchaseHandler);
+    mse.unsubscribe.instantPurchase(instantPurchaseHandler);
     mse.unsubscribe.pageView(pageViewHandler);
     mse.unsubscribe.placeOrder(placeOrderHandler);
     mse.unsubscribe.productPageView(productViewHandler);

--- a/src/handlers/checkout/instantPurchase.ts
+++ b/src/handlers/checkout/instantPurchase.ts
@@ -4,7 +4,10 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createProductCtx, createShoppingCartCtx } from "../../contexts";
 
@@ -19,12 +22,18 @@ const handler = (event: Event): void => {
     const productCtx = createProductCtx(productContext);
     const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
 
+    const context: Array<SelfDescribingJson> = [productCtx];
+
+    if (shoppingCartCtx) {
+        context.push(shoppingCartCtx);
+    }
+
     trackStructEvent({
         category: "checkout",
         action: "instant-purchase",
         label: orderContext.orderId.toString(),
         property: pageContext.pageType,
-        context: [productCtx, shoppingCartCtx],
+        context,
     });
 };
 

--- a/src/handlers/product/addToCart.ts
+++ b/src/handlers/product/addToCart.ts
@@ -4,7 +4,10 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createProductCtx, createShoppingCartCtx } from "../../contexts";
 
@@ -18,11 +21,17 @@ const handler = (event: Event): void => {
     const productCtx = createProductCtx(productContext);
     const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
 
+    const context: Array<SelfDescribingJson> = [productCtx];
+
+    if (shoppingCartCtx) {
+        context.push(shoppingCartCtx);
+    }
+
     trackStructEvent({
         category: "product",
         action: "add-to-cart",
         property: pageContext.pageType,
-        context: [productCtx, shoppingCartCtx],
+        context,
     });
 };
 

--- a/src/handlers/product/view.ts
+++ b/src/handlers/product/view.ts
@@ -4,7 +4,10 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createProductCtx, createShoppingCartCtx } from "../../contexts";
 
@@ -18,11 +21,17 @@ const handler = (event: Event): void => {
     const productCtx = createProductCtx(productContext);
     const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
 
+    const context: Array<SelfDescribingJson> = [productCtx];
+
+    if (shoppingCartCtx) {
+        context.push(shoppingCartCtx);
+    }
+
     trackStructEvent({
         category: "product",
         action: "view",
         property: pageContext.pageType,
-        context: [productCtx, shoppingCartCtx],
+        context,
     });
 };
 

--- a/src/handlers/shoppingCart/view.ts
+++ b/src/handlers/shoppingCart/view.ts
@@ -4,13 +4,22 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createShoppingCartCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
     const { pageContext, shoppingCartContext } = event.eventInfo;
     const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
+
+    const context: Array<SelfDescribingJson> = [];
+
+    if (shoppingCartCtx) {
+        context.push(shoppingCartCtx);
+    }
 
     trackStructEvent({
         category: "shopping-cart",
@@ -19,7 +28,7 @@ const handler = (event: Event): void => {
         // TODO: this should be the cartId, which is a string,
         //       but Snowplow expects a number for value.
         value: 0,
-        context: [shoppingCartCtx],
+        context,
     });
 };
 


### PR DESCRIPTION
## Description

Return `null` if the `ShoppingCart` context does not yet exist.

## Related Issue
 [SEARCH-1382](https://jira.corp.magento.com/browse/SEARCH-1382)

## Motivation and Context

A customer may not have created a `ShoppingCart` yet, so the context creator should handle the case where it doesn't exist.

## How Has This Been Tested?

Tested locally with `jest`, and with the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
