### PR TITLE
fix: remove invalid data type from value field

### DIFF
--- a/src/handlers/checkout/placeOrder.ts
+++ b/src/handlers/checkout/placeOrder.ts
@@ -14,9 +14,6 @@ const handler = (event: Event): void => {
         action: "place-order",
         label: orderContext.orderId.toString(),
         property: pageContext.pageType,
-        // TODO: this should be the cartId, which is a string,
-        //       but Snowplow expects a number for value.
-        value: 0,
     });
 };
 

--- a/src/handlers/shoppingCart/view.ts
+++ b/src/handlers/shoppingCart/view.ts
@@ -25,9 +25,6 @@ const handler = (event: Event): void => {
         category: "shopping-cart",
         action: "view",
         property: pageContext.pageType,
-        // TODO: this should be the cartId, which is a string,
-        //       but Snowplow expects a number for value.
-        value: 0,
         context,
     });
 };

--- a/tests/handlers/checkout/placeOrder.test.ts
+++ b/tests/handlers/checkout/placeOrder.test.ts
@@ -13,6 +13,5 @@ test("sends snowplow event", () => {
         action: "place-order",
         label: "111111",
         property: "pdp",
-        value: 0,
     });
 });

--- a/tests/handlers/shoppingCart/shoppingCartView.test.ts
+++ b/tests/handlers/shoppingCart/shoppingCartView.test.ts
@@ -13,7 +13,6 @@ test("sends snowplow event", () => {
         category: "shopping-cart",
         action: "view",
         property: "pdp",
-        value: 0,
         context: [
             {
                 data: mockShoppingCartCtx,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,6 +7,7 @@ const config = {
     output: {
         filename: "index.js",
         path: path.resolve(__dirname, "dist"),
+        publicPath: "",
         library: {
             name: "MagentoStorefrontEventCollector",
             type: "umd",
@@ -15,7 +16,6 @@ const config = {
         },
         clean: true,
     },
-    publicPath: "",
     module: {
         rules: [
             {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,9 +11,11 @@ const config = {
             name: "MagentoStorefrontEventCollector",
             type: "umd",
             export: "default",
+            umdNamedDefine: true,
         },
         clean: true,
     },
+    publicPath: "",
     module: {
         rules: [
             {


### PR DESCRIPTION
SEARCH-1418

## Description

Remove `cartId` from the Snowplow event `value`.

## Related Issue

[SEARCH-1418](https://jira.corp.magento.com/browse/SEARCH-1418)

## Motivation and Context

The `value` field is intended to be a `number`, but our `cartId` is a `string`. This resulted in us sending `NaN` to Snowplow. In order to reconcile, we are removing `cartId` from the `value` field. This has no impact, as it's already included in the context data, and not used for modeling.

## How Has This Been Tested?

Tested locally with `jest`, as well as with the `example` directory while watching Snowplow events in Kibana.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
