### PR TITLE
SEARCH-1420 | remove js build version

### DIFF
--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -11,8 +11,6 @@ const createContext = (): TrackerContext => {
         schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
         data: {
             magentoJsVersion: pkg.version,
-            // TODO: what do we do now that we run off github actions?
-            magentoJsBuild: "0000",
         },
     };
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7,7 +7,7 @@ const schemas = {
     MAGENTO_EXTENSION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/magento-extension/jsonschema/1-0-0",
     MAGENTO_JS_TRACKER_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/1-0-0",
+        "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
     PRODUCT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/product/jsonschema/2-0-3",
     RECOMMENDATION_UNIT_SCHEMA_URL:

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -195,7 +195,6 @@ type Storefront = {
 
 type Tracker = {
     magentoJsVersion: string;
-    magentoJsBuild: string;
 };
 
 type ExtensionContext = {

--- a/tests/utils/mocks/context.ts
+++ b/tests/utils/mocks/context.ts
@@ -80,7 +80,6 @@ const mockStorefrontCtx = {
 };
 
 const mockTrackerCtx = {
-    magentoJsBuild: "0000",
     magentoJsVersion: pkg.version,
 };
 


### PR DESCRIPTION
## Description

Removing the `magentoJsBuild` field from the `Tracker` context.

## Related Issue

[SEARCH-1420](https://jira.corp.magento.com/browse/SEARCH-1420)

## Motivation and Context

We no longer use Jenkins to build this library, and we never used the build number for modeling or reporting.

## How Has This Been Tested?

Tested locally with `jest` as well as in the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
