### PR TITLE
fix: resolve id type mismatches

### DIFF
--- a/src/contexts/extension.ts
+++ b/src/contexts/extension.ts
@@ -11,7 +11,7 @@ import schemas from "../schemas";
 const createContext = (extension?: MagentoExtension): ExtensionContext => {
     const magentoExtensionCtx = extension ?? mse.context.getMagentoExtension();
 
-    const context = {
+    const context: ExtensionContext = {
         schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
         data: {
             magentoExtensionVersion:

--- a/src/contexts/product.ts
+++ b/src/contexts/product.ts
@@ -11,7 +11,7 @@ import schemas from "../schemas";
 const createContext = (product?: Product): ProductContext => {
     const productCtx = product ?? mse.context.getProduct();
 
-    const context = {
+    const context: ProductContext = {
         schema: schemas.PRODUCT_SCHEMA_URL,
         data: {
             productId: productCtx.productId,

--- a/src/contexts/recommendationUnit.ts
+++ b/src/contexts/recommendationUnit.ts
@@ -22,7 +22,7 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: RecommendationUnitContext = {
         schema: schemas.RECOMMENDATION_UNIT_SCHEMA_URL,
         data: {
             name: unit.unitName,

--- a/src/contexts/recommendedItem.ts
+++ b/src/contexts/recommendedItem.ts
@@ -29,7 +29,7 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: RecommendedItemContext = {
         schema: schemas.RECOMMENDED_ITEM_SCHEMA_URL,
         data: {
             unitId,

--- a/src/contexts/searchInput.ts
+++ b/src/contexts/searchInput.ts
@@ -12,7 +12,7 @@ import { createFilters } from "../utils/search";
 const createContext = (searchInput?: SearchInput): SearchInputContext => {
     const searchInputCtx = searchInput ?? mse.context.getSearchInput();
 
-    const context = {
+    const context: SearchInputContext = {
         schema: schemas.SEARCH_INPUT_SCHEMA_URL,
         data: {
             source: searchInputCtx.source ?? null,

--- a/src/contexts/searchResultCategory.ts
+++ b/src/contexts/searchResultCategory.ts
@@ -21,7 +21,7 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: SearchResultCategoryContext = {
         schema: schemas.SEARCH_RESULT_CATEGORY_SCHEMA_URL,
         data: {
             name: category.name,

--- a/src/contexts/searchResultProduct.ts
+++ b/src/contexts/searchResultProduct.ts
@@ -21,7 +21,7 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: SearchResultProductContext = {
         schema: schemas.SEARCH_RESULT_PRODUCT_SCHEMA_URL,
         data: {
             name: product.name,

--- a/src/contexts/searchResultSuggestion.ts
+++ b/src/contexts/searchResultSuggestion.ts
@@ -21,7 +21,7 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: SearchResultSuggestionContext = {
         schema: schemas.SEARCH_RESULT_SUGGESTION_SCHEMA_URL,
         data: {
             suggestion: suggested.suggestion,

--- a/src/contexts/searchResults.ts
+++ b/src/contexts/searchResults.ts
@@ -11,7 +11,7 @@ import schemas from "../schemas";
 const createContext = (searchResults?: SearchResults): SearchResultsContext => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
 
-    const context = {
+    const context: SearchResultsContext = {
         schema: schemas.SEARCH_RESULTS_SCHEMA_URL,
         data: {
             searchRequestId: searchResultsCtx.searchRequestId,

--- a/src/contexts/shopper.ts
+++ b/src/contexts/shopper.ts
@@ -11,7 +11,7 @@ import schemas from "../schemas";
 const createContext = (shopper?: Shopper): ShopperContext => {
     const shopperCtx = shopper ?? mse.context.getShopper();
 
-    const context = {
+    const context: ShopperContext = {
         schema: schemas.SHOPPER_SCHEMA_URL,
         data: {
             shopperId: shopperCtx.shopperId,

--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -15,13 +15,13 @@ const createShoppingCartItems = (shoppingCart?: ShoppingCart) => {
         return [];
     }
 
-    const shoppingCartItems: Array<ShoppingCartItem> = shoppingCartCtx.items.map(
+    const shoppingCartItems: Array<ShoppingCartItem> = shoppingCartCtx.items.map<ShoppingCartItem>(
         item => ({
             // TODO: what happens if its undefined?
             basePrice: item.prices?.price.value ?? 0,
             // TODO: how do we reconcile string to int
             // suggestion: change snowplow schema to accept string
-            cartItemId: parseInt(item.id) || 0,
+            cartItemId: item.id,
             mainImageUrl: item.product.mainImageUrl ?? undefined,
             // TODO: what happens if its undefined?
             offerPrice: item.prices?.price.value ?? 0,
@@ -45,15 +45,10 @@ const createContext = (
         return null;
     }
 
-    const context = {
+    const context: ShoppingCartContext = {
         schema: schemas.SHOPPING_CART_SCHEMA_URL,
         data: {
-            // TODO: how do we reconcile string to int
-            // suggestion: change snowplow schema to accept string
-            cartId:
-                shoppingCartCtx.id === null
-                    ? null
-                    : parseInt(shoppingCartCtx.id),
+            cartId: shoppingCartCtx.id,
             itemsCount: shoppingCartCtx.totalQuantity,
             items: createShoppingCartItems(shoppingCartCtx),
             // TODO: where does this come from?

--- a/src/contexts/storefront.ts
+++ b/src/contexts/storefront.ts
@@ -11,7 +11,7 @@ import schemas from "../schemas";
 const createContext = (storefront?: StorefrontInstance): StorefrontContext => {
     const storefrontCtx = storefront ?? mse.context.getStorefrontInstance();
 
-    const context = {
+    const context: StorefrontContext = {
         schema: schemas.STOREFRONT_INSTANCE_SCHEMA_URL,
         data: {
             baseCurrencyCode: storefrontCtx.baseCurrencyCode,

--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -7,7 +7,7 @@ import pkg from "../../package.json";
 import schemas from "../schemas";
 
 const createContext = (): TrackerContext => {
-    const context = {
+    const context: TrackerContext = {
         schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
         data: {
             magentoJsVersion: pkg.version,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -25,7 +25,7 @@ const schemas = {
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
     SHOPPING_CART_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/1-0-1",
+        "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/2-0-0",
     SHOPPER_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/shopper/jsonschema/1-0-0",
     STOREFRONT_INSTANCE_SCHEMA_URL:

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -153,25 +153,25 @@ type Shopper = {
 };
 
 type ShoppingCart = {
-    cartId?: number | null;
-    giftMessageSelected?: boolean;
-    giftWrappingSelected?: boolean;
-    items?: Array<ShoppingCartItem>;
+    cartId?: string | null;
     itemsCount: number;
-    possibleOnepageCheckout?: boolean;
-    subtotalAmount?: number;
     subtotalExcludingTax?: number;
+    items?: Array<ShoppingCartItem>;
+    possibleOnepageCheckout?: boolean;
     subtotalIncludingTax?: number;
+    giftMessageSelected?: boolean;
+    subtotalAmount?: number;
+    giftWrappingSelected?: boolean;
 };
 
 type ShoppingCartItem = {
-    basePrice?: number;
-    cartItemId: number;
-    mainImageUrl?: string;
     offerPrice: number;
-    productName: string;
-    productSku: string;
+    basePrice?: number;
     qty: number;
+    productName: string;
+    cartItemId: string;
+    productSku: string;
+    mainImageUrl?: string;
 };
 
 type Storefront = {

--- a/tests/utils/mocks/context.ts
+++ b/tests/utils/mocks/context.ts
@@ -32,13 +32,13 @@ const mockShopperCtx = {
 };
 
 const mockShoppingCartCtx = {
-    cartId: 111111,
+    cartId: "111111",
     giftMessageSelected: false,
     giftWrappingSelected: false,
     items: [
         {
             basePrice: 20.0,
-            cartItemId: 0,
+            cartItemId: "aaaaaa",
             mainImageUrl: undefined,
             offerPrice: 20.0,
             productName: "T-Shirt",
@@ -47,7 +47,7 @@ const mockShoppingCartCtx = {
         },
         {
             basePrice: 50.0,
-            cartItemId: 0,
+            cartItemId: "cccccc",
             mainImageUrl: undefined,
             offerPrice: 50.0,
             productName: "Hoodie",


### PR DESCRIPTION
SEARCH-1421

## Description

Resolved type mismatches with `cartId` and `cartItemId`.

## Related Issue

[SEARCH-1421](https://jira.corp.magento.com/browse/SEARCH-1421)

## Motivation and Context

Snowplow schema expects `string` for `cartId` and `cartItemId` and we were passing `number`.

## How Has This Been Tested?

Tested locally with `jest` and the `example` directory while watching Snowplow Kibana for events.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
