### PR TITLE
feat: support multiple search units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,10 @@
     "packages": {
         "": {
             "name": "@adobe/magento-storefront-event-collector",
-            "version": "0.0.12",
+            "version": "0.0.13",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
-                "@adobe/magento-storefront-events-sdk": "^0.12.0",
                 "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
                 "@snowplow/browser-plugin-performance-timing": "^3.0.1",
                 "@snowplow/browser-tracker": "^3.0.1"
@@ -46,11 +45,6 @@
             "dependencies": {
                 "lodash": "^4.17.15"
             }
-        },
-        "node_modules/@adobe/magento-storefront-events-sdk": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.12.0.tgz",
-            "integrity": "sha512-wqanaDNxUQe8LM2BAN7I1ll5WXhrwT5xFZmA0YI8dQQM2Rv7mk0H8PkmNighCmpKpGNbXm8hooGC4Rr4yqWHAA=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
@@ -15758,11 +15752,6 @@
             "requires": {
                 "lodash": "^4.17.15"
             }
-        },
-        "@adobe/magento-storefront-events-sdk": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.12.0.tgz",
-            "integrity": "sha512-wqanaDNxUQe8LM2BAN7I1ll5WXhrwT5xFZmA0YI8dQQM2Rv7mk0H8PkmNighCmpKpGNbXm8hooGC4Rr4yqWHAA=="
         },
         "@babel/code-frame": {
             "version": "7.12.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
+                "@adobe/magento-storefront-events-sdk": "^0.13.0",
                 "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
                 "@snowplow/browser-plugin-performance-timing": "^3.0.1",
                 "@snowplow/browser-tracker": "^3.0.1"
@@ -45,6 +46,11 @@
             "dependencies": {
                 "lodash": "^4.17.15"
             }
+        },
+        "node_modules/@adobe/magento-storefront-events-sdk": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.13.0.tgz",
+            "integrity": "sha512-AuGyvmK5/hV5xXdzscJXbN7Is8onb2XzybtmhCwF4f90iMEP0UtgGFPgbxtztEFPCOp+AWVnxmMfhlb4px1QPA=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
@@ -1108,7 +1114,6 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
-                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -3114,7 +3119,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -4522,7 +4526,6 @@
             "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
             "dev": true,
             "dependencies": {
-                "@commitlint/load": ">6.1.1",
                 "chalk": "^2.4.1",
                 "commitizen": "^4.0.3",
                 "conventional-commit-types": "^3.0.0",
@@ -5219,8 +5222,7 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "optionator": "^0.8.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -7080,7 +7082,6 @@
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.0",
                 "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4",
                 "wordwrap": "^1.0.0"
             },
             "bin": {
@@ -8835,7 +8836,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -10278,9 +10278,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.6"
-            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -15752,6 +15749,11 @@
             "requires": {
                 "lodash": "^4.17.15"
             }
+        },
+        "@adobe/magento-storefront-events-sdk": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.13.0.tgz",
+            "integrity": "sha512-AuGyvmK5/hV5xXdzscJXbN7Is8onb2XzybtmhCwF4f90iMEP0UtgGFPgbxtztEFPCOp+AWVnxmMfhlb4px1QPA=="
         },
         "@babel/code-frame": {
             "version": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "homepage": "https://github.com/adobe/magento-storefront-event-collector#readme",
     "dependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.1",
-        "@adobe/magento-storefront-events-sdk": "^0.12.0",
         "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
         "@snowplow/browser-plugin-performance-timing": "^3.0.1",
         "@snowplow/browser-tracker": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "homepage": "https://github.com/adobe/magento-storefront-event-collector#readme",
     "dependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.1",
+        "@adobe/magento-storefront-events-sdk": "^0.13.0",
         "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
         "@snowplow/browser-plugin-performance-timing": "^3.0.1",
         "@snowplow/browser-tracker": "^3.0.1"

--- a/src/contexts/searchInput.ts
+++ b/src/contexts/searchInput.ts
@@ -7,23 +7,32 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchInput } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
-import { createFilters } from "../utils/search";
+import { createFilters, getSearchInputUnit } from "../utils/search";
 
-const createContext = (searchInput?: SearchInput): SearchInputContext => {
+const createContext = (
+    searchUnitId: string,
+    searchInput?: SearchInput,
+): SearchInputContext | null => {
     const searchInputCtx = searchInput ?? mse.context.getSearchInput();
+    const searchInputUnit = getSearchInputUnit(searchUnitId, searchInputCtx);
+
+    if (!searchInputUnit) {
+        return null;
+    }
 
     const context: SearchInputContext = {
         schema: schemas.SEARCH_INPUT_SCHEMA_URL,
         data: {
-            source: searchInputCtx.source ?? null,
+            searchUnitId: searchInputUnit.searchUnitId,
+            source: searchInputUnit.source ?? null,
             queryType: "all",
-            searchRequestId: searchInputCtx.searchRequestId,
-            query: searchInputCtx.query,
-            page: searchInputCtx.page,
-            perPage: searchInputCtx.perPage,
-            filters: createFilters(searchInputCtx),
-            sortType: searchInputCtx.sortType,
-            sortOrder: searchInputCtx.sortOrder,
+            searchRequestId: searchInputUnit.searchRequestId,
+            query: searchInputUnit.query,
+            page: searchInputUnit.page,
+            perPage: searchInputUnit.perPage,
+            filters: createFilters(searchInputUnit),
+            sortType: searchInputUnit.sortType,
+            sortOrder: searchInputUnit.sortOrder,
         },
     };
 

--- a/src/contexts/searchResultCategory.ts
+++ b/src/contexts/searchResultCategory.ts
@@ -7,15 +7,25 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
-import { getCategory } from "../utils/search";
+import { getCategory, getSearchResultUnit } from "../utils/search";
 
 const createContext = (
+    searchUnitId: string,
     name: string,
     searchResults?: SearchResults,
 ): SearchResultCategoryContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
 
-    const category = getCategory(name, searchResultsCtx);
+    const searchResultUnit = getSearchResultUnit(
+        searchUnitId,
+        searchResultsCtx,
+    );
+
+    if (!searchResultUnit) {
+        return null;
+    }
+
+    const category = getCategory(name, searchResultUnit);
 
     if (!category) {
         return null;

--- a/src/contexts/searchResultProduct.ts
+++ b/src/contexts/searchResultProduct.ts
@@ -7,15 +7,25 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
-import { getProduct } from "../utils/search";
+import { getProduct, getSearchResultUnit } from "../utils/search";
 
 const createContext = (
+    searchUnitId: string,
     sku: string,
     searchResults?: SearchResults,
 ): SearchResultProductContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
 
-    const product = getProduct(sku, searchResultsCtx);
+    const searchResultUnit = getSearchResultUnit(
+        searchUnitId,
+        searchResultsCtx,
+    );
+
+    if (!searchResultUnit) {
+        return null;
+    }
+
+    const product = getProduct(sku, searchResultUnit);
 
     if (!product) {
         return null;

--- a/src/contexts/searchResultSuggestion.ts
+++ b/src/contexts/searchResultSuggestion.ts
@@ -7,15 +7,25 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
-import { getSuggestion } from "../utils/search";
+import { getSearchResultUnit, getSuggestion } from "../utils/search";
 
 const createContext = (
+    searchUnitId: string,
     suggestion: string,
     searchResults?: SearchResults,
 ): SearchResultSuggestionContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
 
-    const suggested = getSuggestion(suggestion, searchResultsCtx);
+    const searchResultUnit = getSearchResultUnit(
+        searchUnitId,
+        searchResultsCtx,
+    );
+
+    if (!searchResultUnit) {
+        return null;
+    }
+
+    const suggested = getSuggestion(suggestion, searchResultUnit);
 
     if (!suggested) {
         return null;

--- a/src/contexts/searchResults.ts
+++ b/src/contexts/searchResults.ts
@@ -7,23 +7,37 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { getSearchResultUnit } from "../utils/search";
 
-const createContext = (searchResults?: SearchResults): SearchResultsContext => {
+const createContext = (
+    searchUnitId: string,
+    searchResults?: SearchResults,
+): SearchResultsContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
+
+    const searchResultsUnit = getSearchResultUnit(
+        searchUnitId,
+        searchResultsCtx,
+    );
+
+    if (!searchResultsUnit) {
+        return null;
+    }
 
     const context: SearchResultsContext = {
         schema: schemas.SEARCH_RESULTS_SCHEMA_URL,
         data: {
-            searchRequestId: searchResultsCtx.searchRequestId,
-            products: searchResultsCtx.products,
-            categories: searchResultsCtx.categories,
-            suggestions: searchResultsCtx.suggestions,
-            productCount: searchResultsCtx.productCount,
-            categoryCount: searchResultsCtx.categoryCount,
-            suggestionCount: searchResultsCtx.suggestionCount,
-            page: searchResultsCtx.page,
-            perPage: searchResultsCtx.perPage,
-            facets: searchResultsCtx.facets,
+            searchUnitId: searchResultsUnit.searchUnitId,
+            searchRequestId: searchResultsUnit.searchRequestId,
+            products: searchResultsUnit.products,
+            categories: searchResultsUnit.categories,
+            suggestions: searchResultsUnit.suggestions,
+            productCount: searchResultsUnit.productCount,
+            categoryCount: searchResultsUnit.categoryCount,
+            suggestionCount: searchResultsUnit.suggestionCount,
+            page: searchResultsUnit.page,
+            perPage: searchResultsUnit.perPage,
+            facets: searchResultsUnit.facets,
         },
     };
 

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -17,23 +17,38 @@ import {
 
 const handler = (event: Event): void => {
     const {
+        searchUnitId,
         name,
         pageContext,
         searchInputContext,
         searchResultsContext,
     } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
-    const searchResultsCtx = createSearchResultsCtx(searchResultsContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const searchResultsCtx = createSearchResultsCtx(
+        searchUnitId as string,
+        searchResultsContext,
+    );
+
     const searchResultsCategoryCtx = createSearchResultCategoryCtx(
+        searchUnitId as string,
         name as string,
         searchResultsContext,
     );
 
-    const context: Array<SelfDescribingJson> = [
-        searchInputCtx,
-        searchResultsCtx,
-    ];
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
+
+    if (searchResultsCtx) {
+        context.push(searchResultsCtx);
+    }
 
     if (searchResultsCategoryCtx) {
         context.push(searchResultsCategoryCtx);

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -17,23 +17,38 @@ import {
 
 const handler = (event: Event): void => {
     const {
+        searchUnitId,
         sku,
         pageContext,
         searchInputContext,
         searchResultsContext,
     } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
-    const searchResultsCtx = createSearchResultsCtx(searchResultsContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const searchResultsCtx = createSearchResultsCtx(
+        searchUnitId as string,
+        searchResultsContext,
+    );
+
     const searchResultsProductCtx = createSearchResultProductCtx(
+        searchUnitId as string,
         sku as string,
         searchResultsContext,
     );
 
-    const context: Array<SelfDescribingJson> = [
-        searchInputCtx,
-        searchResultsCtx,
-    ];
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
+
+    if (searchResultsCtx) {
+        context.push(searchResultsCtx);
+    }
 
     if (searchResultsProductCtx) {
         context.push(searchResultsProductCtx);

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -4,21 +4,33 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createSearchInputCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const { pageContext, searchInputContext } = event.eventInfo;
+    const { searchUnitId, pageContext, searchInputContext } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
 
     trackStructEvent({
         category: "search",
         action: "api-request-sent",
-        label: searchInputCtx.data.query,
+        label: searchInputCtx?.data.query,
         property: pageContext.pageType,
-        context: [searchInputCtx],
+        context,
     });
 };
 

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -4,26 +4,47 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
     const {
+        searchUnitId,
         pageContext,
         searchInputContext,
         searchResultsContext,
     } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
-    const searchResultsCtx = createSearchResultsCtx(searchResultsContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const searchResultsCtx = createSearchResultsCtx(
+        searchUnitId as string,
+        searchResultsContext,
+    );
+
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
+
+    if (searchResultsCtx) {
+        context.push(searchResultsCtx);
+    }
 
     trackStructEvent({
         category: "search",
         action: "api-response-received",
-        label: searchInputCtx.data.query,
+        label: searchInputCtx?.data.query,
         property: pageContext.pageType,
-        context: [searchInputCtx, searchResultsCtx],
+        context,
     });
 };
 

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -4,25 +4,46 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
 
 import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
     const {
+        searchUnitId,
         pageContext,
         searchInputContext,
         searchResultsContext,
     } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
-    const searchResultsCtx = createSearchResultsCtx(searchResultsContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const searchResultsCtx = createSearchResultsCtx(
+        searchUnitId as string,
+        searchResultsContext,
+    );
+
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
+
+    if (searchResultsCtx) {
+        context.push(searchResultsCtx);
+    }
 
     trackStructEvent({
         category: "search",
         action: "results-view",
         property: pageContext.pageType,
-        context: [searchInputCtx, searchResultsCtx],
+        context,
     });
 };
 

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -17,23 +17,38 @@ import {
 
 const handler = (event: Event): void => {
     const {
+        searchUnitId,
         suggestion,
         pageContext,
         searchInputContext,
         searchResultsContext,
     } = event.eventInfo;
 
-    const searchInputCtx = createSearchInputCtx(searchInputContext);
-    const searchResultsCtx = createSearchResultsCtx(searchResultsContext);
+    const searchInputCtx = createSearchInputCtx(
+        searchUnitId as string,
+        searchInputContext,
+    );
+
+    const searchResultsCtx = createSearchResultsCtx(
+        searchUnitId as string,
+        searchResultsContext,
+    );
+
     const searchResultsSuggestionCtx = createSearchResultSuggestionCtx(
+        searchUnitId as string,
         suggestion as string,
         searchResultsContext,
     );
 
-    const context: Array<SelfDescribingJson> = [
-        searchInputCtx,
-        searchResultsCtx,
-    ];
+    const context: Array<SelfDescribingJson> = [];
+
+    if (searchInputCtx) {
+        context.push(searchInputCtx);
+    }
+
+    if (searchResultsCtx) {
+        context.push(searchResultsCtx);
+    }
 
     if (searchResultsSuggestionCtx) {
         context.push(searchResultsSuggestionCtx);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,13 +15,13 @@ const schemas = {
     RECOMMENDED_ITEM_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-3",
     SEARCH_INPUT_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-6",
+        "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-8",
     SEARCH_RESULT_CATEGORY_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1",
     SEARCH_RESULT_PRODUCT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1",
     SEARCH_RESULTS_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-5",
+        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-6",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
     SHOPPING_CART_SCHEMA_URL:

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -84,6 +84,7 @@ type RecommendedItem = {
 };
 
 type SearchInput = {
+    searchUnitId: string;
     source: string | null;
     queryType: string;
     searchRequestId: string;
@@ -117,6 +118,7 @@ type SearchResultProduct = {
 };
 
 type SearchResults = {
+    searchUnitId: string;
     searchRequestId: string;
     products: Array<SearchResultProduct> | null;
     suggestions: Array<SearchResultSuggestion> | null;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,14 +1,37 @@
 import {
     SearchInput,
-    SearchResultCategory,
+    SearchInputUnit,
     SearchResultProduct,
     SearchResults,
     SearchResultSuggestion,
+    SearchResultUnit,
 } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
+
+const getSearchInputUnit = (
+    searchUnitId: string,
+    ctx: SearchInput,
+): SearchInputUnit | undefined => {
+    const searchInputUnit = ctx.units.find(
+        unit => unit.searchUnitId === searchUnitId,
+    );
+
+    return searchInputUnit;
+};
+
+const getSearchResultUnit = (
+    searchUnitId: string,
+    ctx: SearchResults,
+): SearchResultUnit | undefined => {
+    const searchResultUnit = ctx.units.find(
+        unit => unit.searchUnitId === searchUnitId,
+    );
+
+    return searchResultUnit;
+};
 
 const getCategory = (
     name: string,
-    ctx: SearchResults,
+    ctx: SearchResultUnit,
 ): SearchResultCategory | null => {
     const category = ctx.categories.find(category => category.name === name);
 
@@ -21,7 +44,7 @@ const getCategory = (
 
 const getProduct = (
     sku: string,
-    ctx: SearchResults,
+    ctx: SearchResultUnit,
 ): SearchResultProduct | null => {
     const product = ctx.products.find(product => product.sku === sku);
 
@@ -34,7 +57,7 @@ const getProduct = (
 
 const getSuggestion = (
     suggestion: string,
-    ctx: SearchResults,
+    ctx: SearchResultUnit,
 ): SearchResultSuggestion | null => {
     const suggested = ctx.suggestions.find(s => s.suggestion === suggestion);
 
@@ -45,7 +68,7 @@ const getSuggestion = (
     return suggested;
 };
 
-const createFilters = (ctx: SearchInput): Array<SearchFilter> => {
+const createFilters = (ctx: SearchInputUnit): Array<SearchFilter> => {
     const filters: Array<SearchFilter> = [];
 
     ctx.filters.forEach(filter => {
@@ -90,4 +113,11 @@ const createFilters = (ctx: SearchInput): Array<SearchFilter> => {
     return filters;
 };
 
-export { createFilters, getCategory, getProduct, getSuggestion };
+export {
+    createFilters,
+    getCategory,
+    getProduct,
+    getSearchInputUnit,
+    getSearchResultUnit,
+    getSuggestion,
+};

--- a/tests/contexts/searchInput.test.ts
+++ b/tests/contexts/searchInput.test.ts
@@ -3,7 +3,7 @@ import schemas from "../../src/schemas";
 import { mockSearchInputCtx } from "../utils/mocks";
 
 test("creates context", () => {
-    const ctx = createSearchInputCtx();
+    const ctx = createSearchInputCtx("search-bar");
 
     expect(ctx).toEqual({
         data: mockSearchInputCtx,

--- a/tests/contexts/searchResultCategory.test.ts
+++ b/tests/contexts/searchResultCategory.test.ts
@@ -3,7 +3,7 @@ import schemas from "../../src/schemas";
 import { mockSearchResultCategoryCtx } from "../utils/mocks";
 
 test("creates context", () => {
-    const ctx = createSearchResultCategoryCtx("Pants");
+    const ctx = createSearchResultCategoryCtx("search-bar", "Pants");
 
     expect(ctx).toEqual({
         data: mockSearchResultCategoryCtx,

--- a/tests/contexts/searchResultProduct.test.ts
+++ b/tests/contexts/searchResultProduct.test.ts
@@ -3,7 +3,7 @@ import schemas from "../../src/schemas";
 import { mockSearchResultProductCtx } from "../utils/mocks";
 
 test("creates context", () => {
-    const ctx = createSearchResultProductCtx("abc123");
+    const ctx = createSearchResultProductCtx("search-bar", "abc123");
 
     expect(ctx).toEqual({
         data: mockSearchResultProductCtx,

--- a/tests/contexts/searchResults.test.ts
+++ b/tests/contexts/searchResults.test.ts
@@ -3,7 +3,7 @@ import schemas from "../../src/schemas";
 import { mockSearchResultsCtx } from "../utils/mocks";
 
 test("creates context", () => {
-    const ctx = createSearchResultsCtx();
+    const ctx = createSearchResultsCtx("search-bar");
 
     expect(ctx).toEqual({
         data: mockSearchResultsCtx,

--- a/tests/contexts/searchResultsSuggestion.test.ts
+++ b/tests/contexts/searchResultsSuggestion.test.ts
@@ -3,7 +3,7 @@ import schemas from "../../src/schemas";
 import { mockSearchResultSuggestionCtx } from "../utils/mocks";
 
 test("creates context", () => {
-    const ctx = createSearchResultSuggestionCtx("red pants");
+    const ctx = createSearchResultSuggestionCtx("search-bar", "red pants");
 
     expect(ctx).toEqual({
         data: mockSearchResultSuggestionCtx,

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -11,21 +11,21 @@ import {
 } from "./utils/mocks";
 
 test("gets category", () => {
-    const category = getCategory("Pants", mockSearchResults);
-    expect(category).toEqual(mockSearchResults.categories[0]);
+    const category = getCategory("Pants", mockSearchResults.units[0]);
+    expect(category).toEqual(mockSearchResults.units[0].categories[0]);
 });
 
 test("gets product", () => {
-    const product = getProduct("abc123", mockSearchResults);
-    expect(product).toEqual(mockSearchResults.products[0]);
+    const product = getProduct("abc123", mockSearchResults.units[0]);
+    expect(product).toEqual(mockSearchResults.units[0].products[0]);
 });
 
 test("gets suggestion", () => {
-    const suggestion = getSuggestion("red pants", mockSearchResults);
-    expect(suggestion).toEqual(mockSearchResults.suggestions[0]);
+    const suggestion = getSuggestion("red pants", mockSearchResults.units[0]);
+    expect(suggestion).toEqual(mockSearchResults.units[0].suggestions[0]);
 });
 
 test("creates filters", () => {
-    const filters = createFilters(mockSearchInput);
+    const filters = createFilters(mockSearchInput.units[0]);
     expect(filters).toEqual(mockSearchInputCtx.filters);
 });

--- a/tests/utils/mocks/context.ts
+++ b/tests/utils/mocks/context.ts
@@ -88,6 +88,7 @@ const mockExtensionCtx = {
 };
 
 const mockSearchInputCtx = {
+    searchUnitId: "search-bar",
     source: "search-bar",
     queryType: "all",
     searchRequestId: "abc123",
@@ -131,6 +132,7 @@ const mockSearchResultProductCtx = {
 };
 
 const mockSearchResultsCtx = {
+    searchUnitId: "search-bar",
     searchRequestId: "abc123",
     products: [
         {

--- a/tests/utils/mocks/dataLayer.ts
+++ b/tests/utils/mocks/dataLayer.ts
@@ -281,65 +281,75 @@ const mockShopper: Shopper = {
 };
 
 const mockSearchInput: SearchInput = {
-    searchRequestId: "abc123",
-    source: "search-bar",
-    query: "red patns",
-    page: 1,
-    perPage: 20,
-    filters: [
+    units: [
         {
-            attribute: "size",
-            eq: "small",
-        },
-        {
-            attribute: "category",
-            in: ["bottoms", "mens"],
-        },
-        {
-            attribute: "price",
-            range: { from: 19.99, to: 49.99 },
+            searchUnitId: "search-bar",
+            searchRequestId: "abc123",
+            source: "search-bar",
+            query: "red patns",
+            page: 1,
+            perPage: 20,
+            filters: [
+                {
+                    attribute: "size",
+                    eq: "small",
+                },
+                {
+                    attribute: "category",
+                    in: ["bottoms", "mens"],
+                },
+                {
+                    attribute: "price",
+                    range: { from: 19.99, to: 49.99 },
+                },
+            ],
+            sortType: "relevance",
+            sortOrder: "descending",
         },
     ],
-    sortType: "relevance",
-    sortOrder: "descending",
 };
 
 const mockSearchResults: SearchResults = {
-    searchRequestId: "abc123",
-    products: [
+    units: [
         {
-            name: "Red Pants",
-            sku: "abc123",
-            url: "https://magento.com/red-pants",
-            imageUrl: "https://magento.com/red-pants.jpg",
-            price: 49.99,
-            rank: 1,
+            searchUnitId: "search-bar",
+            searchRequestId: "abc123",
+            products: [
+                {
+                    name: "Red Pants",
+                    sku: "abc123",
+                    url: "https://magento.com/red-pants",
+                    imageUrl: "https://magento.com/red-pants.jpg",
+                    price: 49.99,
+                    rank: 1,
+                },
+            ],
+            suggestions: [
+                {
+                    suggestion: "red pants",
+                    rank: 1,
+                },
+            ],
+            categories: [
+                {
+                    name: "Pants",
+                    url: "https://magento.com/category/pants",
+                    rank: 1,
+                },
+                {
+                    name: "Bottoms",
+                    url: "https://magento.com/category/bottoms",
+                    rank: 2,
+                },
+            ],
+            page: 1,
+            perPage: 20,
+            productCount: 1,
+            categoryCount: 2,
+            suggestionCount: 1,
+            facets: [],
         },
     ],
-    suggestions: [
-        {
-            suggestion: "red pants",
-            rank: 1,
-        },
-    ],
-    categories: [
-        {
-            name: "Pants",
-            url: "https://magento.com/category/pants",
-            rank: 1,
-        },
-        {
-            name: "Bottoms",
-            url: "https://magento.com/category/bottoms",
-            rank: 2,
-        },
-    ],
-    page: 1,
-    perPage: 20,
-    productCount: 1,
-    categoryCount: 2,
-    suggestionCount: 1,
-    facets: [],
 };
 
 const mockReferrerUrl: ReferrerUrl = {
@@ -353,6 +363,7 @@ const mockCustomUrl: CustomUrl = {
 const mockEvent: Event = {
     event: "add-to-cart",
     eventInfo: {
+        searchUnitId: "search-bar",
         unitId: "abc123",
         productId: 111111,
         name: "Pants",


### PR DESCRIPTION
SEARCH-1474

## Description

Support multiple search bars.

## Related Issue

[SEARCH-1474](https://jira.corp.magento.com/browse/SEARCH-1474)

## Motivation and Context

There are a few places in the Magento storefront where there is more than one search bar on a page. Our data layer takes that into account, and so our collector needs to as well.

## How Has This Been Tested?

Tested with `jest` and the `example` directory while monitoring Snowplow Kibana for events.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
