### PR TITLE
fix: dynamically calculate the shopper context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@adobe/magento-storefront-event-collector",
-            "version": "0.0.17",
+            "version": "0.0.18",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
@@ -14496,9 +14496,9 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.0.tgz",
-            "integrity": "sha512-9MlaeNNEk5juw5YL3Xfkvz2gGTsRcXMqfTEAW2mLFWNVsuQEa4jZc4lFB1UZjmA5cyPriCRmOFx+XKV47p5OZg==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.1.tgz",
+            "integrity": "sha512-BLfLa4paMQyf819haKxxbZqA1aLDqsk8XEZLmd7E1eBa0NsEHYFcTWlUlPmYMGhvD/IMi0NcIW3A/G7vzr3oiA==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -26992,9 +26992,9 @@
             }
         },
         "ts-loader": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.0.tgz",
-            "integrity": "sha512-9MlaeNNEk5juw5YL3Xfkvz2gGTsRcXMqfTEAW2mLFWNVsuQEa4jZc4lFB1UZjmA5cyPriCRmOFx+XKV47p5OZg==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.1.tgz",
+            "integrity": "sha512-BLfLa4paMQyf819haKxxbZqA1aLDqsk8XEZLmd7E1eBa0NsEHYFcTWlUlPmYMGhvD/IMi0NcIW3A/G7vzr3oiA==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",

--- a/src/contexts/extension.ts
+++ b/src/contexts/extension.ts
@@ -7,11 +7,19 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { MagentoExtension } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { ExtensionContext } from "../types/contexts";
 
 const createContext = (extension?: MagentoExtension): ExtensionContext => {
     const magentoExtensionCtx = extension ?? mse.context.getMagentoExtension();
 
-    const context: ExtensionContext = {
+    if (!magentoExtensionCtx) {
+        return {
+            schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
+            data: {},
+        };
+    }
+
+    const context = {
         schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
         data: {
             magentoExtensionVersion:

--- a/src/contexts/global.ts
+++ b/src/contexts/global.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { SelfDescribingJson } from "@snowplow/tracker-core";
+import { ContextPrimitive } from "@snowplow/tracker-core";
 
 import {
     createMagentoExtensionCtx,
@@ -12,17 +12,19 @@ import {
     createTrackerCtx,
 } from ".";
 
-const createContext = (): Array<SelfDescribingJson> => {
+const createContext = (): Array<ContextPrimitive> => {
     const magentoExtensionCtx = createMagentoExtensionCtx();
-    const shopperCtx = createShopperCtx();
     const storefrontInstanceCtx = createStorefrontInstanceCtx();
     const trackerCtx = createTrackerCtx();
 
     const contexts = [
-        magentoExtensionCtx,
-        shopperCtx,
-        storefrontInstanceCtx,
+        // static contexts
         trackerCtx,
+        magentoExtensionCtx,
+        storefrontInstanceCtx,
+
+        // dynamic contexts
+        () => createShopperCtx(),
     ];
 
     return contexts;

--- a/src/contexts/product.ts
+++ b/src/contexts/product.ts
@@ -7,10 +7,18 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { Product } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { ProductContext } from "../types/contexts";
 import { createPricing } from "../utils/product";
 
 const createContext = (product?: Product): ProductContext => {
     const productCtx = product ?? mse.context.getProduct();
+
+    if (!productCtx) {
+        return {
+            schema: schemas.PRODUCT_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const context: ProductContext = {
         schema: schemas.PRODUCT_SCHEMA_URL,

--- a/src/contexts/recommendationUnit.ts
+++ b/src/contexts/recommendationUnit.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { Recommendations } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { RecommendationUnitContext } from "../types/contexts";
 import { getUnit } from "../utils/recommendations";
 
 const createContext = (
@@ -15,6 +16,13 @@ const createContext = (
 ): RecommendationUnitContext | null => {
     const recommendationsCtx =
         recommendations ?? mse.context.getRecommendations();
+
+    if (!recommendationsCtx) {
+        return {
+            schema: schemas.RECOMMENDATION_UNIT_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const unit = getUnit(unitId, recommendationsCtx);
 

--- a/src/contexts/recommendedItem.ts
+++ b/src/contexts/recommendedItem.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { Recommendations } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { RecommendedItemContext } from "../types/contexts";
 import { getProduct, getUnit } from "../utils/recommendations";
 
 const createContext = (
@@ -16,6 +17,13 @@ const createContext = (
 ): RecommendedItemContext | null => {
     const recommendationsCtx =
         recommendations ?? mse.context.getRecommendations();
+
+    if (!recommendationsCtx) {
+        return {
+            schema: schemas.RECOMMENDED_ITEM_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const unit = getUnit(unitId, recommendationsCtx);
 

--- a/src/contexts/searchInput.ts
+++ b/src/contexts/searchInput.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchInput } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { SearchInputContext } from "../types/contexts";
 import { createFilters, getSearchInputUnit } from "../utils/search";
 
 const createContext = (
@@ -14,6 +15,14 @@ const createContext = (
     searchInput?: SearchInput,
 ): SearchInputContext | null => {
     const searchInputCtx = searchInput ?? mse.context.getSearchInput();
+
+    if (!searchInputCtx) {
+        return {
+            schema: schemas.SEARCH_INPUT_SCHEMA_URL,
+            data: {},
+        };
+    }
+
     const searchInputUnit = getSearchInputUnit(searchUnitId, searchInputCtx);
 
     if (!searchInputUnit) {

--- a/src/contexts/searchResultCategory.ts
+++ b/src/contexts/searchResultCategory.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { SearchResultCategoryContext } from "../types/contexts";
 import { getCategory, getSearchResultUnit } from "../utils/search";
 
 const createContext = (
@@ -15,6 +16,13 @@ const createContext = (
     searchResults?: SearchResults,
 ): SearchResultCategoryContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
+
+    if (!searchResultsCtx) {
+        return {
+            schema: schemas.SEARCH_RESULT_CATEGORY_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const searchResultUnit = getSearchResultUnit(
         searchUnitId,

--- a/src/contexts/searchResultProduct.ts
+++ b/src/contexts/searchResultProduct.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { SearchResultProductContext } from "../types/contexts";
 import { getProduct, getSearchResultUnit } from "../utils/search";
 
 const createContext = (
@@ -15,6 +16,13 @@ const createContext = (
     searchResults?: SearchResults,
 ): SearchResultProductContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
+
+    if (!searchResultsCtx) {
+        return {
+            schema: schemas.SEARCH_RESULT_PRODUCT_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const searchResultUnit = getSearchResultUnit(
         searchUnitId,

--- a/src/contexts/searchResultSuggestion.ts
+++ b/src/contexts/searchResultSuggestion.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { SearchResultSuggestionContext } from "../types/contexts";
 import { getSearchResultUnit, getSuggestion } from "../utils/search";
 
 const createContext = (
@@ -15,6 +16,13 @@ const createContext = (
     searchResults?: SearchResults,
 ): SearchResultSuggestionContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
+
+    if (!searchResultsCtx) {
+        return {
+            schema: schemas.SEARCH_RESULT_SUGGESTION_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const searchResultUnit = getSearchResultUnit(
         searchUnitId,

--- a/src/contexts/searchResults.ts
+++ b/src/contexts/searchResults.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { SearchResults } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { SearchResultsContext } from "../types/contexts";
 import { getSearchResultUnit } from "../utils/search";
 
 const createContext = (
@@ -14,6 +15,13 @@ const createContext = (
     searchResults?: SearchResults,
 ): SearchResultsContext | null => {
     const searchResultsCtx = searchResults ?? mse.context.getSearchResults();
+
+    if (!searchResultsCtx) {
+        return {
+            schema: schemas.SEARCH_RESULTS_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const searchResultsUnit = getSearchResultUnit(
         searchUnitId,

--- a/src/contexts/shopper.ts
+++ b/src/contexts/shopper.ts
@@ -7,9 +7,17 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { Shopper } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { ShopperContext } from "../types/contexts";
 
 const createContext = (shopper?: Shopper): ShopperContext => {
     const shopperCtx = shopper ?? mse.context.getShopper();
+
+    if (!shopperCtx) {
+        return {
+            schema: schemas.SHOPPER_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const context: ShopperContext = {
         schema: schemas.SHOPPER_SCHEMA_URL,

--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -7,6 +7,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { ShoppingCart } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { ShoppingCartContext, ShoppingCartItem } from "../types/contexts";
 
 const createShoppingCartItems = (shoppingCart?: ShoppingCart) => {
     const shoppingCartCtx = shoppingCart ?? mse.context.getShoppingCart();
@@ -35,6 +36,13 @@ const createContext = (
     shoppingCart?: ShoppingCart,
 ): ShoppingCartContext | null => {
     const shoppingCartCtx = shoppingCart ?? mse.context.getShoppingCart();
+
+    if (!shoppingCartCtx) {
+        return {
+            schema: schemas.SHOPPING_CART_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     if (!shoppingCartCtx) {
         return null;

--- a/src/contexts/storefront.ts
+++ b/src/contexts/storefront.ts
@@ -7,9 +7,17 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import { StorefrontInstance } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 import schemas from "../schemas";
+import { StorefrontContext } from "../types/contexts";
 
 const createContext = (storefront?: StorefrontInstance): StorefrontContext => {
     const storefrontCtx = storefront ?? mse.context.getStorefrontInstance();
+
+    if (!storefrontCtx) {
+        return {
+            schema: schemas.STOREFRONT_INSTANCE_SCHEMA_URL,
+            data: {},
+        };
+    }
 
     const context: StorefrontContext = {
         schema: schemas.STOREFRONT_INSTANCE_SCHEMA_URL,

--- a/src/contexts/tracker.ts
+++ b/src/contexts/tracker.ts
@@ -5,6 +5,7 @@
 
 import pkg from "../../package.json";
 import schemas from "../schemas";
+import { TrackerContext } from "../types/contexts";
 
 const createContext = (): TrackerContext => {
     const context: TrackerContext = {

--- a/src/handlers/checkout/instantPurchase.ts
+++ b/src/handlers/checkout/instantPurchase.ts
@@ -27,8 +27,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "checkout",
         action: "instant-purchase",
-        label: orderContext.orderId.toString(),
-        property: pageContext.pageType,
+        label: orderContext?.orderId.toString(),
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/checkout/placeOrder.ts
+++ b/src/handlers/checkout/placeOrder.ts
@@ -12,8 +12,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "checkout",
         action: "place-order",
-        label: orderContext.orderId.toString(),
-        property: pageContext.pageType,
+        label: orderContext?.orderId.toString(),
+        property: pageContext?.pageType,
     });
 };
 

--- a/src/handlers/product/addToCart.ts
+++ b/src/handlers/product/addToCart.ts
@@ -27,7 +27,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "product",
         action: "add-to-cart",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/product/view.ts
+++ b/src/handlers/product/view.ts
@@ -27,7 +27,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "product",
         action: "view",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/recommendations/recsItemAddToCartClick.ts
+++ b/src/handlers/recommendations/recsItemAddToCartClick.ts
@@ -49,7 +49,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "rec-add-to-cart-click",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         value: product?.rank,
         context,
     });

--- a/src/handlers/recommendations/recsItemClick.ts
+++ b/src/handlers/recommendations/recsItemClick.ts
@@ -49,7 +49,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "rec-click",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         value: product?.rank,
         context,
     });

--- a/src/handlers/recommendations/recsRequestSent.ts
+++ b/src/handlers/recommendations/recsRequestSent.ts
@@ -12,7 +12,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "api-request-sent",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
     });
 };
 

--- a/src/handlers/recommendations/recsResponseReceived.ts
+++ b/src/handlers/recommendations/recsResponseReceived.ts
@@ -10,6 +10,10 @@ import {
     createRecommendationUnitCtx,
     createRecommendedItemCtx,
 } from "../../contexts";
+import {
+    RecommendationUnitContext,
+    RecommendedItemContext,
+} from "../../types/contexts";
 
 const handler = (event: Event): void => {
     const { pageContext, recommendationsContext } = event.eventInfo;
@@ -17,7 +21,7 @@ const handler = (event: Event): void => {
     const recommendationUnitCtxs: Array<RecommendationUnitContext> = [];
     const recommendedItemCtxs: Array<RecommendedItemContext> = [];
 
-    recommendationsContext.units.forEach(unit => {
+    recommendationsContext?.units.forEach(unit => {
         const unitCtx = createRecommendationUnitCtx(
             unit.unitId as string,
             recommendationsContext,
@@ -45,7 +49,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "api-response-received",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context: [...recommendationUnitCtxs, ...recommendedItemCtxs],
     });
 };

--- a/src/handlers/recommendations/recsUnitRender.ts
+++ b/src/handlers/recommendations/recsUnitRender.ts
@@ -46,7 +46,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "impression-render",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/recommendations/recsUnitView.ts
+++ b/src/handlers/recommendations/recsUnitView.ts
@@ -28,7 +28,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "recommendation-unit",
         action: "view",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -57,8 +57,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "category-click",
-        label: searchResultsCategoryCtx?.data.url,
-        property: pageContext.pageType,
+        label: searchResultsCategoryCtx?.data.url as string,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -57,8 +57,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "product-click",
-        label: searchResultsProductCtx?.data.sku,
-        property: pageContext.pageType,
+        label: searchResultsProductCtx?.data.sku as string,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -28,8 +28,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "api-request-sent",
-        label: searchInputCtx?.data.query,
-        property: pageContext.pageType,
+        label: searchInputCtx?.data.query as string,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -42,8 +42,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "api-response-received",
-        label: searchInputCtx?.data.query,
-        property: pageContext.pageType,
+        label: searchInputCtx?.data.query as string,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -42,7 +42,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "results-view",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -57,8 +57,8 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "suggestion-click",
-        label: searchResultsSuggestionCtx?.data.suggestion,
-        property: pageContext.pageType,
+        label: searchResultsSuggestionCtx?.data.suggestion as string,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/handlers/shoppingCart/view.ts
+++ b/src/handlers/shoppingCart/view.ts
@@ -24,7 +24,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "shopping-cart",
         action: "view",
-        property: pageContext.pageType,
+        property: pageContext?.pageType,
         context,
     });
 };

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -1,3 +1,5 @@
+import { SelfDescribingJson } from "@snowplow/tracker-core";
+
 type Extension = {
     magentoExtensionVersion: string;
 };
@@ -204,67 +206,20 @@ type Tracker = {
     magentoJsVersion: string;
 };
 
-type ExtensionContext = {
-    schema: string;
-    data: Extension;
-};
+type SnowplowContext<DataType> = SelfDescribingJson<
+    DataType | Record<string, unknown>
+>;
 
-type ProductContext = {
-    schema: string;
-    data: Product;
-};
-
-type RecommendationUnitContext = {
-    schema: string;
-    data: RecommendationUnit;
-};
-
-type RecommendedItemContext = {
-    schema: string;
-    data: RecommendedItem;
-};
-
-type SearchInputContext = {
-    schema: string;
-    data: SearchInput;
-};
-
-type SearchResultCategoryContext = {
-    schema: string;
-    data: SearchResultCategory;
-};
-
-type SearchResultProductContext = {
-    schema: string;
-    data: SearchResultProduct;
-};
-
-type SearchResultsContext = {
-    schema: string;
-    data: SearchResults;
-};
-
-type SearchResultSuggestionContext = {
-    schema: string;
-    data: SearchResultSuggestion;
-};
-
-type ShopperContext = {
-    schema: string;
-    data: Shopper;
-};
-
-type ShoppingCartContext = {
-    schema: string;
-    data: ShoppingCart;
-};
-
-type StorefrontContext = {
-    schema: string;
-    data: Storefront;
-};
-
-type TrackerContext = {
-    schema: string;
-    data: Tracker;
-};
+type ExtensionContext = SnowplowContext<Extension>;
+type ProductContext = SnowplowContext<Product>;
+type RecommendationUnitContext = SnowplowContext<RecommendationUnit>;
+type RecommendedItemContext = SnowplowContext<RecommendedItem>;
+type SearchInputContext = SnowplowContext<SearchInput>;
+type SearchResultCategoryContext = SnowplowContext<SearchResultCategory>;
+type SearchResultProductContext = SnowplowContext<SearchResultProduct>;
+type SearchResultsContext = SnowplowContext<SearchResults>;
+type SearchResultSuggestionContext = SnowplowContext<SearchResultSuggestion>;
+type ShopperContext = SnowplowContext<Shopper>;
+type ShoppingCartContext = SnowplowContext<ShoppingCart>;
+type StorefrontContext = SnowplowContext<Storefront>;
+type TrackerContext = SnowplowContext<Tracker>;

--- a/src/utils/product.ts
+++ b/src/utils/product.ts
@@ -1,5 +1,7 @@
 import { Product } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
+import { ProductPricing } from "../types/contexts";
+
 const createPricing = (ctx: Product): ProductPricing | undefined => {
     if (!ctx.pricing) {
         return undefined;

--- a/src/utils/recommendations.ts
+++ b/src/utils/recommendations.ts
@@ -8,7 +8,7 @@ const getUnit = (
     unitId: string,
     ctx: Recommendations,
 ): RecommendationUnit | null => {
-    const unit = ctx.units.find(unit => unit.unitId === unitId);
+    const unit = ctx?.units.find(unit => unit.unitId === unitId);
 
     if (!unit) {
         return null;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -7,6 +7,8 @@ import {
     SearchResultUnit,
 } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
+import { SearchFilter, SearchResultCategory } from "../types/contexts";
+
 const getSearchInputUnit = (
     searchUnitId: string,
     ctx: SearchInput,

--- a/tests/contexts/global.test.ts
+++ b/tests/contexts/global.test.ts
@@ -12,20 +12,17 @@ test("creates context", () => {
 
     expect(ctx).toEqual([
         {
-            data: mockExtensionCtx,
-            schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
+            data: mockTrackerCtx,
+            schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
         },
         {
-            data: mockShopperCtx,
-            schema: schemas.SHOPPER_SCHEMA_URL,
+            data: mockExtensionCtx,
+            schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
         },
         {
             data: mockStorefrontCtx,
             schema: schemas.STOREFRONT_INSTANCE_SCHEMA_URL,
         },
-        {
-            data: mockTrackerCtx,
-            schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
-        },
+        expect.any(Function),
     ]);
 });


### PR DESCRIPTION
## Description

Calculate the `shopperContext` at the time the event is fired.

## Related Issue

N/A

## Motivation and Context

The `shopperContext` can change on the client side at any time if the client logs in or logs out. We must recalculate the value when appending it to the `globalContext` list.

## How Has This Been Tested?

Tested with `jest` and the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
