### PR TITLE
fix: dynamically create all global contexts and remove track page view

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -3,8 +3,8 @@
     <head>
         <link rel="stylesheet" href="style.css" />
         <script src="https://unpkg.com/@adobe/magento-storefront-events-sdk/dist/index.js"></script>
-        <script src="/index.js"></script>
         <script src="http://localhost:8080/index.js"></script>
+        <script src="/index.js"></script>
     </head>
 
     <body>

--- a/example/index.js
+++ b/example/index.js
@@ -23,3 +23,5 @@ mse.context.setSearchResults(mockSearchResults);
 mse.context.setShopper(mockShopper);
 mse.context.setShoppingCart(mockShoppingCart);
 mse.context.setStorefrontInstance(mockStorefront);
+
+mse.publish.pageView();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@adobe/magento-storefront-event-collector",
-            "version": "0.0.18",
+            "version": "0.0.19",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
@@ -1756,9 +1756,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.1.tgz",
+            "integrity": "sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -5082,9 +5082,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.730",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
-            "integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA==",
+            "version": "1.3.734",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.734.tgz",
+            "integrity": "sha512-iQF2mjPZ6zNNq45kbJ6MYZYCBNdv2JpGiJC/lVx4tGJWi9MNg73KkL9sWGN4X4I/CP2SBLWsT8nPADZZpAHIyw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -14038,9 +14038,9 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
-            "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+            "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -14773,9 +14773,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.13.6",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-            "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+            "version": "3.13.7",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -15038,9 +15038,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
-            "integrity": "sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
             "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -15069,9 +15069,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.37.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.37.0.tgz",
-            "integrity": "sha512-yvdhgcI6QkQkDe1hINBAJ1UNevqNGTVaCkD2SSJcB8rcrNNl922RI8i2DXUAuNfANoxwsiXXEA4ZPZI9q2oGLA==",
+            "version": "5.37.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.37.1.tgz",
+            "integrity": "sha512-btZjGy/hSjCAAVHw+cKG+L0M+rstlyxbO2C+BOTaQ5/XAnxkDrP5sVbqWhXgo4pL3X2dcOib6rqCP20Zr9PLow==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -15233,9 +15233,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.2.0.tgz",
-            "integrity": "sha512-HVVpHw+5H4lfGasUKjpIkOy9TB27OyKiL13c+dhzVG1w77OQ87b408fp0qKDKQQkNGgShbStDzVJ8sK46JajXg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
+            "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
             "dev": true,
             "dependencies": {
                 "colorette": "^1.2.2",
@@ -17131,9 +17131,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.1.tgz",
+            "integrity": "sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -19751,9 +19751,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.730",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
-            "integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA==",
+            "version": "1.3.734",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.734.tgz",
+            "integrity": "sha512-iQF2mjPZ6zNNq45kbJ6MYZYCBNdv2JpGiJC/lVx4tGJWi9MNg73KkL9sWGN4X4I/CP2SBLWsT8nPADZZpAHIyw==",
             "dev": true
         },
         "emittery": {
@@ -26650,9 +26650,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
-                    "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+                    "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -27196,9 +27196,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.6",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-            "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+            "version": "3.13.7",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
             "dev": true,
             "optional": true
         },
@@ -27416,9 +27416,9 @@
             }
         },
         "watchpack": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
-            "integrity": "sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -27441,9 +27441,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.37.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.37.0.tgz",
-            "integrity": "sha512-yvdhgcI6QkQkDe1hINBAJ1UNevqNGTVaCkD2SSJcB8rcrNNl922RI8i2DXUAuNfANoxwsiXXEA4ZPZI9q2oGLA==",
+            "version": "5.37.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.37.1.tgz",
+            "integrity": "sha512-btZjGy/hSjCAAVHw+cKG+L0M+rstlyxbO2C+BOTaQ5/XAnxkDrP5sVbqWhXgo4pL3X2dcOib6rqCP20Zr9PLow==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -27564,9 +27564,9 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.2.0.tgz",
-            "integrity": "sha512-HVVpHw+5H4lfGasUKjpIkOy9TB27OyKiL13c+dhzVG1w77OQ87b408fp0qKDKQQkNGgShbStDzVJ8sK46JajXg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
+            "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",

--- a/src/contexts/global.ts
+++ b/src/contexts/global.ts
@@ -13,17 +13,10 @@ import {
 } from ".";
 
 const createContext = (): Array<ContextPrimitive> => {
-    const magentoExtensionCtx = createMagentoExtensionCtx();
-    const storefrontInstanceCtx = createStorefrontInstanceCtx();
-    const trackerCtx = createTrackerCtx();
-
     const contexts = [
-        // static contexts
-        trackerCtx,
-        magentoExtensionCtx,
-        storefrontInstanceCtx,
-
-        // dynamic contexts
+        () => createTrackerCtx(),
+        () => createStorefrontInstanceCtx(),
+        () => createMagentoExtensionCtx(),
         () => createShopperCtx(),
     ];
 

--- a/src/snowplow.ts
+++ b/src/snowplow.ts
@@ -64,8 +64,6 @@ const configureSnowplow = ({
         heartbeatDelay: 5,
     });
 
-    trackPageView();
-
     enableLinkClickTracking();
 };
 

--- a/tests/contexts/global.test.ts
+++ b/tests/contexts/global.test.ts
@@ -1,28 +1,12 @@
 import { createGlobalCtx } from "../../src/contexts";
-import schemas from "../../src/schemas";
-import {
-    mockExtensionCtx,
-    mockShopperCtx,
-    mockStorefrontCtx,
-    mockTrackerCtx,
-} from "../utils/mocks";
 
 test("creates context", () => {
     const ctx = createGlobalCtx();
 
     expect(ctx).toEqual([
-        {
-            data: mockTrackerCtx,
-            schema: schemas.MAGENTO_JS_TRACKER_SCHEMA_URL,
-        },
-        {
-            data: mockExtensionCtx,
-            schema: schemas.MAGENTO_EXTENSION_SCHEMA_URL,
-        },
-        {
-            data: mockStorefrontCtx,
-            schema: schemas.STOREFRONT_INSTANCE_SCHEMA_URL,
-        },
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function),
         expect.any(Function),
     ]);
 });


### PR DESCRIPTION
BREAKING CHANGE: TrackPageView is no longer called for you. You must execute this manually.

## Description

Remove the `trackPageView` when the collector is initialized. Create global contexts on demand.

## Related Issue

N/A

## Motivation and Context

This helps integrators not worry so much about what order they initialize the collector and populate the contexts.

## How Has This Been Tested?

Tested with `jest` and the `example` directory while monitoring Snowplow events in Kibana.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
