### PR TITLE
fix: remove unnecessary early return

### DIFF
--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -44,10 +44,6 @@ const createContext = (
         };
     }
 
-    if (!shoppingCartCtx) {
-        return null;
-    }
-
     const context: ShoppingCartContext = {
         schema: schemas.SHOPPING_CART_SCHEMA_URL,
         data: {

--- a/src/handlers/checkout/placeOrder.ts
+++ b/src/handlers/checkout/placeOrder.ts
@@ -4,16 +4,30 @@
  */
 
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
-import { trackStructEvent } from "@snowplow/browser-tracker";
+import {
+    SelfDescribingJson,
+    trackStructEvent,
+} from "@snowplow/browser-tracker";
+
+import { createShoppingCartCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const { pageContext, orderContext } = event.eventInfo;
+    const { pageContext, orderContext, shoppingCartContext } = event.eventInfo;
+
+    const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
+
+    const context: Array<SelfDescribingJson> = [];
+
+    if (shoppingCartCtx) {
+        context.push(shoppingCartCtx);
+    }
 
     trackStructEvent({
         category: "checkout",
         action: "place-order",
         label: orderContext?.orderId.toString(),
         property: pageContext?.pageType,
+        context,
     });
 };
 

--- a/tests/handlers/checkout/placeOrder.test.ts
+++ b/tests/handlers/checkout/placeOrder.test.ts
@@ -1,7 +1,8 @@
 import { trackStructEvent } from "@snowplow/browser-tracker";
 
 import { placeOrderHandler } from "../../../src/handlers";
-import { mockEvent } from "../../utils/mocks";
+import schemas from "../../../src/schemas";
+import { mockEvent, mockShoppingCartCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     placeOrderHandler(mockEvent);
@@ -13,5 +14,11 @@ test("sends snowplow event", () => {
         action: "place-order",
         label: "111111",
         property: "pdp",
+        context: [
+            {
+                data: mockShoppingCartCtx,
+                schema: schemas.SHOPPING_CART_SCHEMA_URL,
+            },
+        ],
     });
 });


### PR DESCRIPTION
## Description

Removing duplicate early `return` statement.

## Related Issue

N/A

## Motivation and Context

Just a little code cleanup!

## How Has This Been Tested?

Tested with `jest`!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
