### PR TITLE
fix: remove search input context from events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@adobe/magento-storefront-event-collector",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
@@ -48,9 +48,9 @@
             }
         },
         "node_modules/@adobe/magento-storefront-events-sdk": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.16.0.tgz",
-            "integrity": "sha512-sOOvxlAa7k05ki4VhwLFvLAY/iYrLPAdoAkEuXt+qxmiH/w3EpG8MiJyYIIj910Dxp4bG/5KNPna4pNeK80eQA=="
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.16.1.tgz",
+            "integrity": "sha512-4x+zkWTshQUHybuJQacNbZShyLjOdN+ph4uBS1f6TLD62d7vP1GLWLtwffMfSF0QNt+hXCTx2P5nqa4zzQ45mw=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
@@ -4829,9 +4829,9 @@
             "dev": true
         },
         "node_modules/dns-packet": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.3.tgz",
-            "integrity": "sha512-dDwDMOJU+m6Qx+LhltSV+BWNrMaTqx3eXkAqgt/iouWTXGZMffg1rOSnG2xa3lWqmJ9xTBc7fgIe/css4S1rxA==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
             "dev": true,
             "dependencies": {
                 "ip": "^1.1.0",
@@ -5024,9 +5024,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.738",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
-            "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==",
+            "version": "1.3.739",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+            "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -14497,9 +14497,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.13.7",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
-            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+            "version": "3.13.8",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+            "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -15457,9 +15457,9 @@
             }
         },
         "@adobe/magento-storefront-events-sdk": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.16.0.tgz",
-            "integrity": "sha512-sOOvxlAa7k05ki4VhwLFvLAY/iYrLPAdoAkEuXt+qxmiH/w3EpG8MiJyYIIj910Dxp4bG/5KNPna4pNeK80eQA=="
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.16.1.tgz",
+            "integrity": "sha512-4x+zkWTshQUHybuJQacNbZShyLjOdN+ph4uBS1f6TLD62d7vP1GLWLtwffMfSF0QNt+hXCTx2P5nqa4zzQ45mw=="
         },
         "@babel/code-frame": {
             "version": "7.12.13",
@@ -19241,9 +19241,9 @@
             "dev": true
         },
         "dns-packet": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.3.tgz",
-            "integrity": "sha512-dDwDMOJU+m6Qx+LhltSV+BWNrMaTqx3eXkAqgt/iouWTXGZMffg1rOSnG2xa3lWqmJ9xTBc7fgIe/css4S1rxA==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
             "dev": true,
             "requires": {
                 "ip": "^1.1.0",
@@ -19409,9 +19409,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.738",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
-            "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==",
+            "version": "1.3.739",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+            "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
             "dev": true
         },
         "emittery": {
@@ -26678,9 +26678,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.7",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
-            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+            "version": "3.13.8",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+            "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
             "dev": true,
             "optional": true
         },

--- a/src/contexts/recommendedItem.ts
+++ b/src/contexts/recommendedItem.ts
@@ -42,7 +42,6 @@ const createContext = (
         data: {
             unitId,
             serviceRank: product.rank,
-            // TODO: is this right?
             displayRank: product.rank,
             name: product.name,
             sku: product.sku,

--- a/src/contexts/shoppingCart.ts
+++ b/src/contexts/shoppingCart.ts
@@ -19,8 +19,6 @@ const createShoppingCartItems = (shoppingCart?: ShoppingCart) => {
     const shoppingCartItems: Array<ShoppingCartItem> =
         shoppingCartCtx.items.map<ShoppingCartItem>(item => ({
             basePrice: item.prices.price.value,
-            // TODO: how do we reconcile string to int
-            // suggestion: change snowplow schema to accept string
             cartItemId: item.id,
             mainImageUrl: item.product.mainImageUrl ?? undefined,
             offerPrice: item.prices.price.value,
@@ -50,17 +48,11 @@ const createContext = (
             cartId: shoppingCartCtx.id,
             itemsCount: shoppingCartCtx.totalQuantity,
             items: createShoppingCartItems(shoppingCartCtx),
-            // TODO: where does this come from?
-            // specific to luma
-            // why do we care?
-            possibleOnepageCheckout: false,
+            possibleOnepageCheckout: shoppingCartCtx.possibleOnepageCheckout,
             subtotalExcludingTax:
                 shoppingCartCtx.prices?.subtotalExcludingTax?.value,
             subtotalIncludingTax:
                 shoppingCartCtx.prices?.subtotalIncludingTax?.value,
-            // TODO: where does these come from?
-            // calculated from what the client knows
-            // should be simplified
             giftMessageSelected: false,
             giftWrappingSelected: false,
         },

--- a/src/handlers/search/searchCategoryClick.ts
+++ b/src/handlers/search/searchCategoryClick.ts
@@ -10,24 +10,13 @@ import {
 } from "@snowplow/browser-tracker";
 
 import {
-    createSearchInputCtx,
     createSearchResultCategoryCtx,
     createSearchResultsCtx,
 } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const {
-        searchUnitId,
-        name,
-        pageContext,
-        searchInputContext,
-        searchResultsContext,
-    } = event.eventInfo;
-
-    const searchInputCtx = createSearchInputCtx(
-        searchUnitId as string,
-        searchInputContext,
-    );
+    const { searchUnitId, name, pageContext, searchResultsContext } =
+        event.eventInfo;
 
     const searchResultsCtx = createSearchResultsCtx(
         searchUnitId as string,
@@ -41,10 +30,6 @@ const handler = (event: Event): void => {
     );
 
     const context: Array<SelfDescribingJson> = [];
-
-    if (searchInputCtx) {
-        context.push(searchInputCtx);
-    }
 
     if (searchResultsCtx) {
         context.push(searchResultsCtx);

--- a/src/handlers/search/searchProductClick.ts
+++ b/src/handlers/search/searchProductClick.ts
@@ -10,24 +10,13 @@ import {
 } from "@snowplow/browser-tracker";
 
 import {
-    createSearchInputCtx,
     createSearchResultProductCtx,
     createSearchResultsCtx,
 } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const {
-        searchUnitId,
-        sku,
-        pageContext,
-        searchInputContext,
-        searchResultsContext,
-    } = event.eventInfo;
-
-    const searchInputCtx = createSearchInputCtx(
-        searchUnitId as string,
-        searchInputContext,
-    );
+    const { searchUnitId, sku, pageContext, searchResultsContext } =
+        event.eventInfo;
 
     const searchResultsCtx = createSearchResultsCtx(
         searchUnitId as string,
@@ -41,10 +30,6 @@ const handler = (event: Event): void => {
     );
 
     const context: Array<SelfDescribingJson> = [];
-
-    if (searchInputCtx) {
-        context.push(searchInputCtx);
-    }
 
     if (searchResultsCtx) {
         context.push(searchResultsCtx);

--- a/src/handlers/search/searchRequestSent.ts
+++ b/src/handlers/search/searchRequestSent.ts
@@ -28,7 +28,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "api-request-sent",
-        label: searchInputCtx?.data.query as string,
+        label: searchInputCtx?.data.searchRequestId as string,
         property: pageContext?.pageType,
         context,
     });

--- a/src/handlers/search/searchResponseReceived.ts
+++ b/src/handlers/search/searchResponseReceived.ts
@@ -9,20 +9,10 @@ import {
     trackStructEvent,
 } from "@snowplow/browser-tracker";
 
-import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
+import { createSearchResultsCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const {
-        searchUnitId,
-        pageContext,
-        searchInputContext,
-        searchResultsContext,
-    } = event.eventInfo;
-
-    const searchInputCtx = createSearchInputCtx(
-        searchUnitId as string,
-        searchInputContext,
-    );
+    const { searchUnitId, pageContext, searchResultsContext } = event.eventInfo;
 
     const searchResultsCtx = createSearchResultsCtx(
         searchUnitId as string,
@@ -31,10 +21,6 @@ const handler = (event: Event): void => {
 
     const context: Array<SelfDescribingJson> = [];
 
-    if (searchInputCtx) {
-        context.push(searchInputCtx);
-    }
-
     if (searchResultsCtx) {
         context.push(searchResultsCtx);
     }
@@ -42,7 +28,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "api-response-received",
-        label: searchInputCtx?.data.query as string,
+        label: searchResultsCtx?.data.searchRequestId as string,
         property: pageContext?.pageType,
         context,
     });

--- a/src/handlers/search/searchResultsView.ts
+++ b/src/handlers/search/searchResultsView.ts
@@ -9,20 +9,10 @@ import {
     trackStructEvent,
 } from "@snowplow/browser-tracker";
 
-import { createSearchInputCtx, createSearchResultsCtx } from "../../contexts";
+import { createSearchResultsCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const {
-        searchUnitId,
-        pageContext,
-        searchInputContext,
-        searchResultsContext,
-    } = event.eventInfo;
-
-    const searchInputCtx = createSearchInputCtx(
-        searchUnitId as string,
-        searchInputContext,
-    );
+    const { searchUnitId, pageContext, searchResultsContext } = event.eventInfo;
 
     const searchResultsCtx = createSearchResultsCtx(
         searchUnitId as string,
@@ -31,10 +21,6 @@ const handler = (event: Event): void => {
 
     const context: Array<SelfDescribingJson> = [];
 
-    if (searchInputCtx) {
-        context.push(searchInputCtx);
-    }
-
     if (searchResultsCtx) {
         context.push(searchResultsCtx);
     }
@@ -42,6 +28,7 @@ const handler = (event: Event): void => {
     trackStructEvent({
         category: "search",
         action: "results-view",
+        label: searchResultsCtx?.data.searchRequestId as string,
         property: pageContext?.pageType,
         context,
     });

--- a/src/handlers/search/searchSuggestionClick.ts
+++ b/src/handlers/search/searchSuggestionClick.ts
@@ -10,24 +10,13 @@ import {
 } from "@snowplow/browser-tracker";
 
 import {
-    createSearchInputCtx,
     createSearchResultsCtx,
     createSearchResultSuggestionCtx,
 } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const {
-        searchUnitId,
-        suggestion,
-        pageContext,
-        searchInputContext,
-        searchResultsContext,
-    } = event.eventInfo;
-
-    const searchInputCtx = createSearchInputCtx(
-        searchUnitId as string,
-        searchInputContext,
-    );
+    const { searchUnitId, suggestion, pageContext, searchResultsContext } =
+        event.eventInfo;
 
     const searchResultsCtx = createSearchResultsCtx(
         searchUnitId as string,
@@ -41,10 +30,6 @@ const handler = (event: Event): void => {
     );
 
     const context: Array<SelfDescribingJson> = [];
-
-    if (searchInputCtx) {
-        context.push(searchInputCtx);
-    }
 
     if (searchResultsCtx) {
         context.push(searchResultsCtx);

--- a/tests/handlers/search/categoryClick.test.ts
+++ b/tests/handlers/search/categoryClick.test.ts
@@ -4,7 +4,6 @@ import { searchCategoryClickHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
 import {
     mockEvent,
-    mockSearchInputCtx,
     mockSearchResultCategoryCtx,
     mockSearchResultsCtx,
 } from "../../utils/mocks";
@@ -20,10 +19,6 @@ test("sends snowplow event", () => {
         label: "https://magento.com/category/pants",
         property: "pdp",
         context: [
-            {
-                data: mockSearchInputCtx,
-                schema: schemas.SEARCH_INPUT_SCHEMA_URL,
-            },
             {
                 data: mockSearchResultsCtx,
                 schema: schemas.SEARCH_RESULTS_SCHEMA_URL,

--- a/tests/handlers/search/productClick.test.ts
+++ b/tests/handlers/search/productClick.test.ts
@@ -4,7 +4,6 @@ import { searchProductClickHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
 import {
     mockEvent,
-    mockSearchInputCtx,
     mockSearchResultProductCtx,
     mockSearchResultsCtx,
 } from "../../utils/mocks";
@@ -20,10 +19,6 @@ test("sends snowplow event", () => {
         label: "abc123",
         property: "pdp",
         context: [
-            {
-                data: mockSearchInputCtx,
-                schema: schemas.SEARCH_INPUT_SCHEMA_URL,
-            },
             {
                 data: mockSearchResultsCtx,
                 schema: schemas.SEARCH_RESULTS_SCHEMA_URL,

--- a/tests/handlers/search/requestSent.test.ts
+++ b/tests/handlers/search/requestSent.test.ts
@@ -12,7 +12,7 @@ test("sends snowplow event", () => {
     expect(trackStructEvent).toHaveBeenCalledWith({
         category: "search",
         action: "api-request-sent",
-        label: "red patns",
+        label: "abc123",
         property: "pdp",
         context: [
             {

--- a/tests/handlers/search/responseReceived.test.ts
+++ b/tests/handlers/search/responseReceived.test.ts
@@ -2,11 +2,7 @@ import { trackStructEvent } from "@snowplow/browser-tracker";
 
 import { searchResponseReceivedHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
-import {
-    mockEvent,
-    mockSearchInputCtx,
-    mockSearchResultsCtx,
-} from "../../utils/mocks";
+import { mockEvent, mockSearchResultsCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     searchResponseReceivedHandler(mockEvent);
@@ -16,13 +12,9 @@ test("sends snowplow event", () => {
     expect(trackStructEvent).toHaveBeenCalledWith({
         category: "search",
         action: "api-response-received",
-        label: "red patns",
+        label: "abc123",
         property: "pdp",
         context: [
-            {
-                data: mockSearchInputCtx,
-                schema: schemas.SEARCH_INPUT_SCHEMA_URL,
-            },
             {
                 data: mockSearchResultsCtx,
                 schema: schemas.SEARCH_RESULTS_SCHEMA_URL,

--- a/tests/handlers/search/resultsView.test.ts
+++ b/tests/handlers/search/resultsView.test.ts
@@ -2,11 +2,7 @@ import { trackStructEvent } from "@snowplow/browser-tracker";
 
 import { searchResultsViewHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
-import {
-    mockEvent,
-    mockSearchInputCtx,
-    mockSearchResultsCtx,
-} from "../../utils/mocks";
+import { mockEvent, mockSearchResultsCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     searchResultsViewHandler(mockEvent);
@@ -16,12 +12,9 @@ test("sends snowplow event", () => {
     expect(trackStructEvent).toHaveBeenCalledWith({
         category: "search",
         action: "results-view",
+        label: "abc123",
         property: "pdp",
         context: [
-            {
-                data: mockSearchInputCtx,
-                schema: schemas.SEARCH_INPUT_SCHEMA_URL,
-            },
             {
                 data: mockSearchResultsCtx,
                 schema: schemas.SEARCH_RESULTS_SCHEMA_URL,

--- a/tests/handlers/search/suggestionClick.test.ts
+++ b/tests/handlers/search/suggestionClick.test.ts
@@ -4,7 +4,6 @@ import { searchSuggestionClickHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
 import {
     mockEvent,
-    mockSearchInputCtx,
     mockSearchResultsCtx,
     mockSearchResultSuggestionCtx,
 } from "../../utils/mocks";
@@ -20,10 +19,6 @@ test("sends snowplow event", () => {
         label: "red pants",
         property: "pdp",
         context: [
-            {
-                data: mockSearchInputCtx,
-                schema: schemas.SEARCH_INPUT_SCHEMA_URL,
-            },
             {
                 data: mockSearchResultsCtx,
                 schema: schemas.SEARCH_RESULTS_SCHEMA_URL,

--- a/tests/utils/mocks/dataLayer.ts
+++ b/tests/utils/mocks/dataLayer.ts
@@ -259,6 +259,7 @@ const mockShoppingCart: ShoppingCart = {
         },
     },
     totalQuantity: 2,
+    possibleOnepageCheckout: false,
 };
 
 const mockStorefront: StorefrontInstance = {


### PR DESCRIPTION
## Description

Remove `SearchInput` context from a few events. Support `possibleOnepageCheckout`.

## Related Issue

[DATA-3096](https://jira.corp.magento.com/browse/DATA-3096)

## Motivation and Context

Prevents search input from being mismatched with the results. Maintains data parity with the legacy collector.

## How Has This Been Tested?

Tested with `jest` and the `example` directory while watching Snowplow events in Kibana.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
