### PR TITLE
fix: make price optional to support b2b

### DIFF
--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -58,7 +58,7 @@ type RecommendedItem = {
     sku: string;
     url: string;
     imageUrl: string | null;
-    prices: {
+    prices?: {
         maximum: {
             final: number | null;
             regular: number | null;
@@ -84,7 +84,7 @@ type RecommendedItem = {
             }>;
         };
     };
-    currencyCode: string | null;
+    currencyCode?: string | null;
 };
 
 type SearchInput = {
@@ -122,7 +122,7 @@ type SearchResultProduct = {
     rank: number;
     sku: string;
     imageUrl: string;
-    price: number;
+    price?: number;
 };
 
 type SearchResults = {


### PR DESCRIPTION
## Description

Make `price` and `currencyCode` optional.

## Related Issue

[DATA-3400](https://jira.corp.magento.com/browse/DATA-3400)

## Motivation and Context

Enables customer group pricing for B2B.

## How Has This Been Tested?

Ran existing `jest` tests.

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
