### PR TITLE
fix(recommendeditem.ts): do not add prices to recommendation item con…

### DIFF
--- a/src/contexts/recommendedItem.ts
+++ b/src/contexts/recommendedItem.ts
@@ -47,7 +47,7 @@ const createContext = (
             sku: product.sku,
             url: product.url,
             imageUrl: product.image?.url ?? null,
-            prices: {
+            ...(product.prices && {prices: {
                 maximum: {
                     final: product.prices.maximum.final,
                     regular: product.prices.maximum.regular,
@@ -84,7 +84,7 @@ const createContext = (
                             }),
                         ),
                 },
-            },
+            }}),
             currencyCode: product.currency,
         },
     };

--- a/src/contexts/recommendedItem.ts
+++ b/src/contexts/recommendedItem.ts
@@ -47,44 +47,46 @@ const createContext = (
             sku: product.sku,
             url: product.url,
             imageUrl: product.image?.url ?? null,
-            ...(product.prices && {prices: {
-                maximum: {
-                    final: product.prices.maximum.final,
-                    regular: product.prices.maximum.regular,
-                    finalAdjustments:
-                        product.prices.maximum.finalAdjustments.map(
-                            finalAdjustment => ({
-                                code: finalAdjustment.code,
-                                amount: finalAdjustment.amount,
-                            }),
-                        ),
-                    regularAdjustments:
-                        product.prices.maximum.regularAdjustments.map(
-                            finalAdjustment => ({
-                                code: finalAdjustment.code,
-                                amount: finalAdjustment.amount,
-                            }),
-                        ),
+            ...(product.prices && {
+                prices: {
+                    maximum: {
+                        final: product.prices.maximum.final,
+                        regular: product.prices.maximum.regular,
+                        finalAdjustments:
+                            product.prices.maximum.finalAdjustments.map(
+                                finalAdjustment => ({
+                                    code: finalAdjustment.code,
+                                    amount: finalAdjustment.amount,
+                                }),
+                            ),
+                        regularAdjustments:
+                            product.prices.maximum.regularAdjustments.map(
+                                finalAdjustment => ({
+                                    code: finalAdjustment.code,
+                                    amount: finalAdjustment.amount,
+                                }),
+                            ),
+                    },
+                    minimum: {
+                        final: product.prices.minimum.final,
+                        regular: product.prices.minimum.regular,
+                        finalAdjustments:
+                            product.prices.minimum.finalAdjustments.map(
+                                finalAdjustment => ({
+                                    code: finalAdjustment.code,
+                                    amount: finalAdjustment.amount,
+                                }),
+                            ),
+                        regularAdjustments:
+                            product.prices.minimum.regularAdjustments.map(
+                                finalAdjustment => ({
+                                    code: finalAdjustment.code,
+                                    amount: finalAdjustment.amount,
+                                }),
+                            ),
+                    },
                 },
-                minimum: {
-                    final: product.prices.minimum.final,
-                    regular: product.prices.minimum.regular,
-                    finalAdjustments:
-                        product.prices.minimum.finalAdjustments.map(
-                            finalAdjustment => ({
-                                code: finalAdjustment.code,
-                                amount: finalAdjustment.amount,
-                            }),
-                        ),
-                    regularAdjustments:
-                        product.prices.minimum.regularAdjustments.map(
-                            finalAdjustment => ({
-                                code: finalAdjustment.code,
-                                amount: finalAdjustment.amount,
-                            }),
-                        ),
-                },
-            }}),
+            }),
             currencyCode: product.currency,
         },
     };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -13,7 +13,7 @@ const schemas = {
     RECOMMENDATION_UNIT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
     RECOMMENDED_ITEM_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-3",
+        "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-4",
     SEARCH_INPUT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-input/jsonschema/1-0-11",
     SEARCH_RESULT_CATEGORY_SCHEMA_URL:

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,7 +19,7 @@ const schemas = {
     SEARCH_RESULT_CATEGORY_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1",
     SEARCH_RESULT_PRODUCT_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-1",
+        "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-2",
     SEARCH_RESULTS_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-7",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:


### PR DESCRIPTION
…text if they are not present

DATA-3400

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The prices object in the `RecommendedProduct` schema is optional, but was treated as required when building the context in recommendedItem.ts. This change checks for the existence of `product.prices` before trying to use it/add it to the context object.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested with local magento store and confirmed events in good bucket of snowplow when missing prices from recommendation unit.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
