### PR TITLE
fix: make the search results price optional

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,7 +21,7 @@ const schemas = {
     SEARCH_RESULT_PRODUCT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-2",
     SEARCH_RESULTS_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-7",
+        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-8",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
     SHOPPING_CART_SCHEMA_URL:


### PR DESCRIPTION
## Description

Point to the latest `search-results` Snowplow schema.

## Related Issue

[SEARCH-1686](https://jira.corp.magento.com/browse/SEARCH-1686)

## Motivation and Context

Makes the `price` property in the `search-results` schema optional.

## How Has This Been Tested?

Tested locally in my Magento environment.

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
