### PR TITLE
SEARCH-1696 | Capture api-execution-time in search adaptor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
             }
         },
         "@adobe/magento-storefront-events-sdk": {
-            "version": "0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f.tgz",
-            "integrity": "sha512-kMxq0MFlMtMKGHoXgHRCNF0DaMP3yEkc2Keoqfyobr3TkpHIIchAmWruw93WkK+CUyf7ITOFMBfMeex5KNrNKA=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-1.1.0.tgz",
+            "integrity": "sha512-G/rTZlmPWlBk8YGGWib9E8XerxN/HeYhdA54gK3BAlWsaXvLekOV+abykRJpUfPDYJ3wVVI4TDsrtVaN/RWRRw=="
         },
         "@babel/code-frame": {
             "version": "7.12.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,9 @@
             }
         },
         "@adobe/magento-storefront-events-sdk": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-1.0.2.tgz",
-            "integrity": "sha512-j/hnjNDi7N+Eh3vJW3mytH+4c9glMUPhdmAO+M6JeY+1X7R7cPmjgiwtzVUmKFWj/DZc31NZHYVH+67MQE1bIw==",
-            "dev": true
+            "version": "0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f",
+            "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f.tgz",
+            "integrity": "sha512-kMxq0MFlMtMKGHoXgHRCNF0DaMP3yEkc2Keoqfyobr3TkpHIIchAmWruw93WkK+CUyf7ITOFMBfMeex5KNrNKA=="
         },
         "@babel/code-frame": {
             "version": "7.12.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@adobe/magento-storefront-events-sdk": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@adobe/magento-storefront-events-sdk/-/magento-storefront-events-sdk-1.1.0.tgz",
-            "integrity": "sha512-G/rTZlmPWlBk8YGGWib9E8XerxN/HeYhdA54gK3BAlWsaXvLekOV+abykRJpUfPDYJ3wVVI4TDsrtVaN/RWRRw=="
+            "integrity": "sha512-G/rTZlmPWlBk8YGGWib9E8XerxN/HeYhdA54gK3BAlWsaXvLekOV+abykRJpUfPDYJ3wVVI4TDsrtVaN/RWRRw==",
+            "dev": true
         },
         "@babel/code-frame": {
             "version": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "homepage": "https://github.com/adobe/magento-storefront-event-collector#readme",
     "dependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.2",
-        "@adobe/magento-storefront-events-sdk": "^1.1.0",
         "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
         "@snowplow/browser-plugin-performance-timing": "^3.0.1",
         "@snowplow/browser-tracker": "^3.0.1"
     },
     "devDependencies": {
+        "@adobe/magento-storefront-events-sdk": "^1.1.0",
         "@types/jest": "^26.0.23",
         "@typescript-eslint/eslint-plugin": "^4.2.0",
         "@typescript-eslint/parser": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "homepage": "https://github.com/adobe/magento-storefront-event-collector#readme",
     "dependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.2",
-        "@adobe/magento-storefront-events-sdk": "0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f",
+        "@adobe/magento-storefront-events-sdk": "^1.1.0",
         "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
         "@snowplow/browser-plugin-performance-timing": "^3.0.1",
         "@snowplow/browser-tracker": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "homepage": "https://github.com/adobe/magento-storefront-event-collector#readme",
     "dependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.2",
+        "@adobe/magento-storefront-events-sdk": "0.0.0-ce044a23f3162f824741abd6f9396b907b9a328f",
         "@snowplow/browser-plugin-link-click-tracking": "^3.0.2",
         "@snowplow/browser-plugin-performance-timing": "^3.0.1",
         "@snowplow/browser-tracker": "^3.0.1"
     },
     "devDependencies": {
-        "@adobe/magento-storefront-events-sdk": "^1.0.2",
         "@types/jest": "^26.0.23",
         "@typescript-eslint/eslint-plugin": "^4.2.0",
         "@typescript-eslint/parser": "^4.2.0",

--- a/src/contexts/searchResults.ts
+++ b/src/contexts/searchResults.ts
@@ -37,6 +37,7 @@ const createContext = (
         data: {
             searchUnitId: searchResultsUnit.searchUnitId,
             searchRequestId: searchResultsUnit.searchRequestId,
+            executionTime: searchResultsUnit.executionTime,
             products: searchResultsUnit.products,
             categories: searchResultsUnit.categories,
             suggestions: searchResultsUnit.suggestions,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,7 +21,7 @@ const schemas = {
     SEARCH_RESULT_PRODUCT_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-2",
     SEARCH_RESULTS_SCHEMA_URL:
-        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-8",
+        "iglu:com.adobe.magento.entity/search-results/jsonschema/1-0-9",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
     SHOPPING_CART_SCHEMA_URL:

--- a/src/types/contexts.d.ts
+++ b/src/types/contexts.d.ts
@@ -128,6 +128,7 @@ type SearchResultProduct = {
 type SearchResults = {
     searchUnitId: string;
     searchRequestId: string;
+    executionTime?: number;
     products: Array<SearchResultProduct> | null;
     suggestions: Array<SearchResultSuggestion> | null;
     categories: Array<SearchResultCategory> | null;

--- a/tests/utils/mocks/context.ts
+++ b/tests/utils/mocks/context.ts
@@ -138,6 +138,7 @@ const mockSearchResultProductCtx = {
 const mockSearchResultsCtx = {
     searchUnitId: "search-bar",
     searchRequestId: "abc123",
+    executionTime: 378.39,
     products: [
         {
             imageUrl: "https://magento.com/red-pants.jpg",

--- a/tests/utils/mocks/dataLayer.ts
+++ b/tests/utils/mocks/dataLayer.ts
@@ -324,6 +324,7 @@ const mockSearchResults: SearchResults = {
         {
             searchUnitId: "search-bar",
             searchRequestId: "abc123",
+            executionTime: 378.39,
             products: [
                 {
                     name: "Red Pants",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
     plugins: [
         new webpack.DefinePlugin({
             SNOWPLOW_COLLECTOR_URL: JSON.stringify(
-                "https://com-magento-prod1.mini.snplow.net",
+                "https://com-magento-qa1.collector.snplow.net",
             ),
             SNOWPLOW_COLLECTOR_PATH: JSON.stringify(
                 "/com.snowplowanalytics.snowplow/tp2",


### PR DESCRIPTION
## Description

Add an optional `executionTime` field to the `SearchResults` context.

## Related Issue

[SEARCH-1696](https://jira.corp.magento.com/browse/SEARCH-1696)

## Motivation and Context

Supports performance tracking of our Search API.

## How Has This Been Tested?

Locally with `jest`.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
