### PR TITLE
DINT-264: mapping correct page name

### DIFF
--- a/src/handlers/page/viewAEP.ts
+++ b/src/handlers/page/viewAEP.ts
@@ -1,10 +1,25 @@
+/* eslint-disable no-console */
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
 
 import { sendEvent } from "../../alloy";
 import { BeaconSchema } from "../../types/aep";
 
+/**
+ * AEP Handler for page view event
+ */
 const aepHandler = async (event: Event): Promise<void> => {
     const { pageContext, debugContext } = event.eventInfo;
+
+    // if we have a name return name, else return type
+    const handlePageName = () => {
+        const { pageType: type, pageName: name } = pageContext;
+
+        if (!name || !type) {
+            return undefined;
+        }
+
+        return name ? name : type;
+    };
 
     const payload: BeaconSchema = {
         _id: debugContext?.eventId,
@@ -18,7 +33,7 @@ const aepHandler = async (event: Event): Promise<void> => {
                 siteSection: pageContext.pageType,
                 /** temporary until sdk update gets merged */
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                name: (pageContext as any).pageName || undefined,
+                name: handlePageName(),
             },
         },
     };


### PR DESCRIPTION
- Two fields get sent over from magento/adobe-commerce, `pageContext.pageType` and `pageExtended.action` and a third is set on document.title
- Magento is sending over the page name on the `pageContext.pageType` field and that's the page "name" that is already mapped to siteSection, while pageName is being mapped to `web.webPageDetails.name` if it exists.
- My assumption is to also use pageName to set `web.webPageDetails.name` or if pageName is undefined, use pageType.
- We also want this to work with non-luma stores, so the assumption that pageType will always be there could be wrong as well, so we need to change this interface in the sdk
- ...but this ticket could mean we want the document title of the actual page???